### PR TITLE
Fix for weapon equip delay bypass #112

### DIFF
--- a/MechanicsCore/src/main/java/me/deecaad/core/events/triggers/EquipListener.java
+++ b/MechanicsCore/src/main/java/me/deecaad/core/events/triggers/EquipListener.java
@@ -87,14 +87,9 @@ public class EquipListener implements Listener {
         // Swapping items doesn't cause any changes in the inventory, so it is
         // not covered by the player injection system.
         if (!(isEmpty(inv.getItem(e.getNewSlot())) && isEmpty(inv.getItem(e.getPreviousSlot())))) {
-            new BukkitRunnable() {
-                @Override
-                public void run() {
-                    ItemStack old = inv.getItem(e.getPreviousSlot());
-                    ItemStack current = inv.getItem(e.getNewSlot());
-                    Bukkit.getPluginManager().callEvent(new EntityEquipmentEvent(player, EquipmentSlot.HAND, old, current));
-                }
-            }.runTask(MechanicsCore.getPlugin());
+            ItemStack old = inv.getItem(e.getPreviousSlot());
+            ItemStack current = inv.getItem(e.getNewSlot());
+            Bukkit.getPluginManager().callEvent(new EntityEquipmentEvent(player, EquipmentSlot.HAND, old, current));
         }
     }
 


### PR DESCRIPTION
Contains potential fix for bug #112.  

`PlayerItemHeldEvent` in `EquipListener` currently calls `EntityEquipmentEvent` 1 tick late which causes things like `Weapon_Equip_Delay` can be bypassed.  

I don't see why this would cause other issues nor I didn't notice any with some tests. If you (@CJCrafter) don't know either, simply merge this.