### PR TITLE
Fix #315: Weapons with explosions are incompatible with WorldGuard

### DIFF
--- a/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/weapon/explode/BlockDamage.java
+++ b/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/weapon/explode/BlockDamage.java
@@ -21,6 +21,7 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
+import java.util.stream.Collectors;
 import java.util.*;
 
 public class BlockDamage implements Serializer<BlockDamage> {
@@ -142,7 +143,7 @@ public class BlockDamage implements Serializer<BlockDamage> {
     }
 
     public List<Block> filterBreakbleBlocks(List<Block> blocks) {
-        return blocks.stream().filter(block -> getBreakMode(block.getType()) == BreakMode.BREAK).toList();
+        return blocks.stream().filter(block -> getBreakMode(block.getType()) == BreakMode.BREAK).collect(Collectors.toList());
     }
 
     public int getDurability(Block block) {


### PR DESCRIPTION
`Stream#toList()` returns an unmodifiable `List` which doesn't play well with plugins wanting to modify the list of exploded blocks. Using `Collectors.toList()` will ensure that a mutable ArrayList instance is returned, restoring support for WorldGuard