### PR TITLE
Add Repair only broken Weapon and Consume on Use RepairKit

### DIFF
--- a/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/listeners/RepairItemListener.java
+++ b/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/listeners/RepairItemListener.java
@@ -136,15 +136,22 @@ public class RepairItemListener implements Listener {
             // complicated, so we handle it separately.
             if (CustomTag.BROKEN_WEAPON.hasString(weapon)) {
                 repairBrokenItem(event);
-                return;
+
+            }else{
+
+                // Only attempt to repair guns with proper repair items
+                if (weaponTitle == null || event.getCursor() == null)
+                    return;
+
+                Configuration config = WeaponMechanics.getConfigurations();
+                CustomDurability customDurability = config.getObject(weaponTitle + ".Shoot.Custom_Durability", CustomDurability.class);
+                if (customDurability.isRepairOnlyBroken()){
+                    return;
+                }
+
+                CastData cast = new CastData(event.getWhoClicked(), weaponTitle, weapon);
+                repair(weapon, weaponTitle, event.getCursor(), cast);
             }
-
-            // Only attempt to repair guns with proper repair items
-            if (weaponTitle == null || event.getCursor() == null)
-                return;
-
-            CastData cast = new CastData(event.getWhoClicked(), weaponTitle, weapon);
-            repair(weapon, weaponTitle, event.getCursor(), cast);
         }
     }
 
@@ -221,6 +228,10 @@ public class RepairItemListener implements Listener {
                 CustomTag.DURABILITY.setInteger(weapon, durability + availableRepair);
                 repairItem.setAmount(0);
                 if (kit.getBreakMechanics() != null) kit.getBreakMechanics().use(cast);
+            }
+
+            if(kit.consumeOnUse){
+                repairItem.setAmount(0);
             }
 
             // When "overrideMaxDurabilityLoss" is -1, it is automatically set
@@ -316,7 +327,7 @@ public class RepairItemListener implements Listener {
         private Set<String> weapons;
         private Set<String> armors;
         private Mechanics breakMechanics;
-
+        private boolean consumeOnUse;
         /**
          * Default constructor for serializers.
          */
@@ -324,7 +335,7 @@ public class RepairItemListener implements Listener {
         }
 
         public RepairKit(ItemStack item, int totalDurability, int overrideMaxDurabilityLoss, boolean blacklist,
-                         Set<String> weapons, Set<String> armors, Mechanics breakMechanics) {
+                         Set<String> weapons, Set<String> armors, Mechanics breakMechanics, boolean consumeOnUse) {
             this.item = item;
             this.totalDurability = totalDurability;
             this.overrideMaxDurabilityLoss = overrideMaxDurabilityLoss;
@@ -332,6 +343,7 @@ public class RepairItemListener implements Listener {
             this.weapons = weapons;
             this.armors = armors;
             this.breakMechanics = breakMechanics;
+            this.consumeOnUse = consumeOnUse;
         }
 
         public ItemStack getItem() {
@@ -360,6 +372,14 @@ public class RepairItemListener implements Listener {
 
         public Mechanics getBreakMechanics() {
             return breakMechanics;
+        }
+
+        public boolean isConsumeOnUse() {
+            return consumeOnUse;
+        }
+
+        public void setConsumeOnUse(boolean consumeOnUse) {
+            this.consumeOnUse = consumeOnUse;
         }
 
         /**
@@ -400,8 +420,9 @@ public class RepairItemListener implements Listener {
             ItemStack item = new ItemSerializer().serializeWithTags(data.move("Item"), tags);
 
             Mechanics breakMechanics = data.of("Break_Mechanics").serialize(Mechanics.class);
+            boolean consumeOnUse = data.of("Consume_On_Use").get(false);
 
-            return new RepairKit(item, totalDurability, overrideMaxDurabilityLoss, blacklist, weapons, armors, breakMechanics);
+            return new RepairKit(item, totalDurability, overrideMaxDurabilityLoss, blacklist, weapons, armors, breakMechanics, consumeOnUse);
         }
     }
 }

--- a/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/listeners/RepairItemListener.java
+++ b/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/listeners/RepairItemListener.java
@@ -137,7 +137,7 @@ public class RepairItemListener implements Listener {
             if (CustomTag.BROKEN_WEAPON.hasString(weapon)) {
                 repairBrokenItem(event);
 
-            }else{
+            } else {
 
                 // Only attempt to repair guns with proper repair items
                 if (weaponTitle == null || event.getCursor() == null)
@@ -145,7 +145,7 @@ public class RepairItemListener implements Listener {
 
                 Configuration config = WeaponMechanics.getConfigurations();
                 CustomDurability customDurability = config.getObject(weaponTitle + ".Shoot.Custom_Durability", CustomDurability.class);
-                if (customDurability.isRepairOnlyBroken()){
+                if (customDurability.isRepairOnlyBroken()) {
                     return;
                 }
 
@@ -230,7 +230,7 @@ public class RepairItemListener implements Listener {
                 if (kit.getBreakMechanics() != null) kit.getBreakMechanics().use(cast);
             }
 
-            if(kit.consumeOnUse){
+            if (kit.consumeOnUse) {
                 repairItem.setAmount(0);
             }
 
@@ -328,6 +328,7 @@ public class RepairItemListener implements Listener {
         private Set<String> armors;
         private Mechanics breakMechanics;
         private boolean consumeOnUse;
+
         /**
          * Default constructor for serializers.
          */

--- a/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/weapon/shoot/CustomDurability.java
+++ b/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/weapon/shoot/CustomDurability.java
@@ -46,6 +46,7 @@ public class CustomDurability implements Serializer<CustomDurability> {
     private int repairPerExp;
     private Mechanics repairMechanics;
     private Mechanics denyRepairMechanics;
+    private boolean repairOnlyBroken;
 
     /**
      * Default constructor for serializer
@@ -55,7 +56,8 @@ public class CustomDurability implements Serializer<CustomDurability> {
 
     public CustomDurability(int maxDurability, int minMaxDurability, int loseMaxDurabilityPerRepair, int durabilityPerShot,
                             double chance, ItemStack replaceItem, Mechanics durabilityMechanics, Mechanics breakMechanics,
-                            Map<ItemStack, Integer> repairItems, int repairPerExp, Mechanics repairMechanics, Mechanics denyRepairMechanics) {
+                            Map<ItemStack, Integer> repairItems, int repairPerExp, Mechanics repairMechanics, Mechanics denyRepairMechanics,
+                            boolean repairOnlyBroken) {
         this.maxDurability = maxDurability;
         this.minMaxDurability = minMaxDurability;
         this.loseMaxDurabilityPerRepair = loseMaxDurabilityPerRepair;
@@ -68,6 +70,7 @@ public class CustomDurability implements Serializer<CustomDurability> {
         this.repairPerExp = repairPerExp;
         this.repairMechanics = repairMechanics;
         this.denyRepairMechanics = denyRepairMechanics;
+        this.repairOnlyBroken = repairOnlyBroken;
     }
 
     public int getMaxDurability() {
@@ -164,6 +167,14 @@ public class CustomDurability implements Serializer<CustomDurability> {
 
     public void setDenyRepairMechanics(Mechanics denyRepairMechanics) {
         this.denyRepairMechanics = denyRepairMechanics;
+    }
+
+    public boolean isRepairOnlyBroken() {
+        return repairOnlyBroken;
+    }
+
+    public void setRepairOnlyBroken(boolean repairOnlyBroken) {
+        this.repairOnlyBroken = repairOnlyBroken;
     }
 
     /**
@@ -358,9 +369,11 @@ public class CustomDurability implements Serializer<CustomDurability> {
         int repairPerExp = data.of("Repair_Per_Exp").assertPositive().getInt(0);
         Mechanics repairMechanics = data.of("Repair_Mechanics").serialize(Mechanics.class);
         Mechanics denyRepairMechanics = data.of("Deny_Repair_Mechanics").serialize(Mechanics.class);
+        boolean repairOnlyBroken = data.of("Repair_Only_Broken").getBool(false);
 
         return new CustomDurability(maxDurability, minMaxDurability, loseMaxDurabilityPerRepair, durabilityPerShot,
-                chance, replaceItem, durabilityMechanics, breakMechanics, repairItems, repairPerExp, repairMechanics, denyRepairMechanics);
+                chance, replaceItem, durabilityMechanics, breakMechanics, repairItems, repairPerExp, repairMechanics, denyRepairMechanics,
+                repairOnlyBroken);
     }
 
     /**


### PR DESCRIPTION
- added setting to use repair only when weapon is broken.
- has been added so when repair kit is used it disappears regardless of durability