### PR TITLE
Fix NPE in explosion mechanics 

### DIFF
--- a/MechanicsCore/src/main/java/me/deecaad/core/mechanics/PlayerEffectMechanicList.java
+++ b/MechanicsCore/src/main/java/me/deecaad/core/mechanics/PlayerEffectMechanicList.java
@@ -72,7 +72,9 @@ public final class PlayerEffectMechanicList extends Mechanic implements JarSearc
                 }
 
                 // Rewrite our saved variations
-                target.setTargetEntity(targetEntity);
+                if (targetEntity != null) {
+                    target.setTargetEntity(targetEntity);
+                }
                 target.setTargetLocation(supplier);
 
                 // Play the mechanic


### PR DESCRIPTION
The `CastData` for explosion mechanics is created with a null `targetEntity` which can remain null - specifically, I believe, if one of these mechanics has `listenerConditions` which no online player satisfies. Whatever the case, a null check is needed here. 

Fixes #411.