### PR TITLE
Fix/mythicmob skills not applying damage

### DIFF
--- a/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/listeners/trigger/TriggerEntityListeners.java
+++ b/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/listeners/trigger/TriggerEntityListeners.java
@@ -67,7 +67,7 @@ public class TriggerEntityListeners implements Listener {
             return;
 
         // MythicMobs damage skill support. Holding a gun while dealing damage normally triggers this
-        if (victim.hasMetadata("doing-skill-damage"))
+        if (victim.hasMetadata("skill-damage"))
             return;
 
         EntityDamageEvent.DamageCause cause = e.getCause();


### PR DESCRIPTION
Implemented a solution where both weapon damage and MythicMob damage are now applied. However, I'm uncertain if this is the optimal approach, so please provide feedback on your preferred method.