### PR TITLE
save name and lore

### DIFF
--- a/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/weapon/info/WeaponItemSerializer.java
+++ b/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/weapon/info/WeaponItemSerializer.java
@@ -1,5 +1,6 @@
 package me.deecaad.weaponmechanics.weapon.info;
 
+import me.deecaad.core.file.Configuration;
 import me.deecaad.core.file.SerializeData;
 import me.deecaad.core.file.SerializerException;
 import me.deecaad.core.file.serializers.ItemSerializer;
@@ -42,6 +43,11 @@ public class WeaponItemSerializer extends ItemSerializer {
                 "Purchase WMC to 'fake' the crossbow animation for other players: https://www.spigotmc.org/resources/104539/");
 
         String weaponTitle = data.key.split("\\.")[0];
+
+        // Saving display name and lore for use in WeaponMechanicsPlus to auto update items
+        Configuration config = WeaponMechanics.getConfigurations();
+        config.set(weaponTitle + ".Info.Weapon_Item.Name", data.of("Name").assertExists().get());
+        config.set(weaponTitle + ".Info.Weapon_Item.Lore", data.of("Lore").assertExists().get());
 
         // Ensure the weapon title uses the correct format, mostly for other plugin compatibility
         Pattern pattern = Pattern.compile("[A-Za-z0-9_]+");

--- a/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/weapon/info/WeaponItemSerializer.java
+++ b/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/weapon/info/WeaponItemSerializer.java
@@ -4,6 +4,7 @@ import me.deecaad.core.file.Configuration;
 import me.deecaad.core.file.SerializeData;
 import me.deecaad.core.file.SerializerException;
 import me.deecaad.core.file.serializers.ItemSerializer;
+import me.deecaad.core.utils.StringUtil;
 import me.deecaad.weaponmechanics.WeaponMechanics;
 import me.deecaad.weaponmechanics.utils.CustomTag;
 import me.deecaad.weaponmechanics.weapon.shoot.SelectiveFireState;
@@ -11,6 +12,7 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Pattern;
 
 /**
@@ -46,8 +48,12 @@ public class WeaponItemSerializer extends ItemSerializer {
 
         // Saving display name and lore for use in WeaponMechanicsPlus to auto update items
         Configuration config = WeaponMechanics.getConfigurations();
-        config.set(weaponTitle + ".Info.Weapon_Item.Name", data.of("Name").assertExists().get());
-        config.set(weaponTitle + ".Info.Weapon_Item.Lore", data.of("Lore").assertExists().get());
+        config.set(weaponTitle + ".Info.Weapon_Item.Name", "<!italic>" + data.of("Name").assertExists().getAdventure());
+        List<String> unparsedLore = ((List<String>) data.of("Lore").assertExists().get())
+            .stream()
+            .map(line -> "<!italic>" + StringUtil.colorAdventure(line))
+            .toList();
+        config.set(weaponTitle + ".Info.Weapon_Item.Lore", unparsedLore);
 
         // Ensure the weapon title uses the correct format, mostly for other plugin compatibility
         Pattern pattern = Pattern.compile("[A-Za-z0-9_]+");


### PR DESCRIPTION
Saving the display name and lore of the weapon item allows us to easily grab it in WeaponMechanicsPlus