### PR TITLE
Revert reload changes from #460

### DIFF
--- a/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/weapon/reload/ReloadHandler.java
+++ b/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/weapon/reload/ReloadHandler.java
@@ -240,27 +240,22 @@ public class ReloadHandler implements IValidator, TriggerListener {
         // This is necessary for events to be used correctly
         handData.setReloadData(weaponTitle, weaponStack);
 
+        ItemStack oldWeaponStack = weaponStack.clone();
         ChainTask reloadTask = new ChainTask(reloadDuration) {
 
             private int unloadedAmount;
 
             @Override
             public void task() {
-                // Check if the slot is still the same
-                ItemStack currentItem = mainhand ? entityWrapper.getEntity().getEquipment().getItemInMainHand() : entityWrapper.getEntity().getEquipment().getItemInOffHand();
-                if (!currentItem.isSimilar(weaponStack)) {
+                ItemStack taskReference = mainhand ? entityWrapper.getEntity().getEquipment().getItemInMainHand() : entityWrapper.getEntity().getEquipment().getItemInOffHand();
+                String newWeaponTitle = taskReference.hasItemMeta() ? CustomTag.WEAPON_TITLE.getString(taskReference) : null;
+                if (!taskReference.hasItemMeta() || !weaponTitle.equals(newWeaponTitle)) {
                     // if weapon changes, it stops the task
                     handData.stopReloadingTasks();
                     return;
                 }
 
-                ItemStack taskReference = mainhand ? entityWrapper.getEntity().getEquipment().getItemInMainHand() : entityWrapper.getEntity().getEquipment().getItemInOffHand();
-                if (!taskReference.hasItemMeta()) {
-                    handData.stopReloadingTasks();
-                    return;
-                }
                 handData.setReloadData(weaponTitle, taskReference);
-
                 int ammoLeft = getAmmoLeft(taskReference, weaponTitle);
 
                 // Here creating this again since this may change if there isn't enough ammo...

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Versions of the 2 plugins stored in this repo.
-mechanicsCoreVersion=3.4.11
-weaponMechanicsVersion=3.4.12
+mechanicsCoreVersion=3.4.12
+weaponMechanicsVersion=3.4.13
 
 # Version of the resource pack
 resourcePackVersion=2.1.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Versions of the 2 plugins stored in this repo.
-mechanicsCoreVersion=3.4.12
-weaponMechanicsVersion=3.4.13
+mechanicsCoreVersion=3.4.13
+weaponMechanicsVersion=3.4.14
 
 # Version of the resource pack
 resourcePackVersion=2.1.2


### PR DESCRIPTION
Fix #461 

For now, reverting the reload changes from #460. I added a simple check to see if the weapon type changes. Unfortunately, there isn't really a good way to check if the item stack reference itself changes (because it always WILL change). A better solution for "ammo injection" might be to cancel reloads sooner using the EntityEquipmentEvent or similar. 