### PR TITLE
fix entity wrapper task causing NPE onReload

### DIFF
--- a/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/WeaponMechanics.java
+++ b/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/WeaponMechanics.java
@@ -614,7 +614,9 @@ public class WeaponMechanics {
         // This won't cancel move tasks on Folia... We have to do it manually
         foliaScheduler.cancelTasks();
         for (EntityWrapper entityWrapper : entityWrappers.values()) {
-            entityWrapper.getMoveTask().cancel();
+            TaskImplementation<Void> moveTask = entityWrapper.getMoveTask();
+            if (moveTask != null)
+                moveTask.cancel();
         }
 
         BlockDamageData.regenerateAll();


### PR DESCRIPTION
```yaml
[22:44:21 INFO]: Cyber_QA issued server command: /wm reload
[22:44:21 WARN]: java.lang.NullPointerException: Cannot invoke "me.deecaad.core.lib.scheduler.TaskImplementation.cancel()" because the return value of "me.deecaad.weaponmechanics.wrappers.EntityWrapper.getMoveTask()" is null
[22:44:21 WARN]:        at WeaponMechanics-3.5.0.jar//me.deecaad.weaponmechanics.WeaponMechanics.onDisable(WeaponMechanics.java:620)
[22:44:21 WARN]:        at WeaponMechanics-3.5.0.jar//me.deecaad.weaponmechanics.WeaponMechanics.onReload(WeaponMechanics.java:574)
[22:44:21 WARN]:        at WeaponMechanics-3.5.0.jar//me.deecaad.weaponmechanics.commands.WeaponMechanicsCommand.lambda$build$17(WeaponMechanicsCommand.java:209)
```
Fixed this