### PR TITLE
Cj/recoil event hotfix

### DIFF
--- a/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/weapon/weaponevents/WeaponRecoilEvent.java
+++ b/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/weapon/weaponevents/WeaponRecoilEvent.java
@@ -130,4 +130,8 @@ public class WeaponRecoilEvent extends WeaponEvent implements Cancellable {
     public @NotNull HandlerList getHandlers() {
         return HANDLERS;
     }
+
+    public static @NotNull HandlerList getHandlerList() {
+        return HANDLERS;
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Versions of the 2 plugins stored in this repo.
 mechanicsCoreVersion=4.0.0
-weaponMechanicsVersion=4.0.0
+weaponMechanicsVersion=4.0.1
 
 # Version of the resource pack
 resourcePackVersion=3.0.0


### PR DESCRIPTION
Fixes an error that makes the new `WeaponRecoilEvent` not work, and spam the console with errors. 

Fixes #391 