### PR TITLE
Cj/legacy support

### DIFF
--- a/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/WeaponMechanics.java
+++ b/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/WeaponMechanics.java
@@ -45,6 +45,7 @@ import me.deecaad.weaponmechanics.listeners.trigger.TriggerPlayerListeners;
 import me.deecaad.weaponmechanics.packetlisteners.OutAbilitiesListener;
 import me.deecaad.weaponmechanics.packetlisteners.OutEntityEffectListener;
 import me.deecaad.weaponmechanics.packetlisteners.OutRemoveEntityEffectListener;
+import me.deecaad.weaponmechanics.packetlisteners.OutSetSlotBobFix;
 import me.deecaad.weaponmechanics.weapon.WeaponHandler;
 import me.deecaad.weaponmechanics.weapon.damage.AssistData;
 import me.deecaad.weaponmechanics.weapon.damage.BlockDamageData;
@@ -413,6 +414,8 @@ public class WeaponMechanics {
         em.registerListener(new OutAbilitiesListener(), PacketListenerPriority.NORMAL);
         em.registerListener(new OutEntityEffectListener(), PacketListenerPriority.NORMAL);
         em.registerListener(new OutRemoveEntityEffectListener(), PacketListenerPriority.NORMAL);
+        if (basicConfiguration.getBoolean("Fix_Bobbing_Legacy", false))
+            em.registerListener(new OutSetSlotBobFix(javaPlugin), PacketListenerPriority.NORMAL);
     }
 
     void registerCommands() {

--- a/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/packetlisteners/OutSetSlotBobFix.java
+++ b/WeaponMechanics/src/main/java/me/deecaad/weaponmechanics/packetlisteners/OutSetSlotBobFix.java
@@ -1,0 +1,154 @@
+package me.deecaad.weaponmechanics.packetlisteners;
+
+import com.github.retrooper.packetevents.event.PacketListener;
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSetSlot;
+import io.github.retrooper.packetevents.util.SpigotConversionUtil;
+import me.deecaad.weaponmechanics.utils.CustomTag;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerItemHeldEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.Plugin;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public class OutSetSlotBobFix implements Listener, PacketListener {
+
+    private final Map<Player, SimpleItemData> mainHand;
+    private final Map<Player, SimpleItemData> offHand;
+
+    public OutSetSlotBobFix(Plugin plugin) {
+        mainHand = new HashMap<>();
+        offHand = new HashMap<>();
+
+        Bukkit.getPluginManager().registerEvents(this, plugin);
+    }
+
+    @EventHandler
+    public void drop(PlayerDropItemEvent event) {
+        mainHand.put(event.getPlayer(), null);
+    }
+
+    @EventHandler
+    public void click(InventoryClickEvent event) {
+        HumanEntity humanEntity = event.getWhoClicked();
+        if (!(humanEntity instanceof Player player))
+            return;
+        mainHand.put(player, null);
+        offHand.put(player, null);
+    }
+
+    @EventHandler
+    public void click(InventoryDragEvent event) {
+        HumanEntity humanEntity = event.getWhoClicked();
+        if (!(humanEntity instanceof Player player))
+            return;
+        mainHand.put(player, null);
+        offHand.put(player, null);
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void held(PlayerItemHeldEvent e) {
+        mainHand.put(e.getPlayer(), null);
+    }
+
+    @EventHandler
+    public void quit(PlayerQuitEvent event) {
+        mainHand.remove(event.getPlayer());
+        offHand.remove(event.getPlayer());
+    }
+
+    @Override
+    public void onPacketSend(PacketSendEvent event) {
+        if (event.getPacketType() != PacketType.Play.Server.SET_SLOT)
+            return;
+        // 1.21.4 has resource pack feature to disable bobbing
+        if (!event.getUser().getClientVersion().isOlderThan(ClientVersion.V_1_21_4))
+            return;
+
+        Player player = event.getPlayer();
+        WrapperPlayServerSetSlot wrapper = new WrapperPlayServerSetSlot(event);
+
+        // 0 is the player's inventory.
+        if (wrapper.getWindowId() != 0)
+            return;
+
+        int slot = wrapper.getSlot();
+        boolean mainHand = slot == 36 + player.getInventory().getHeldItemSlot();
+        if (!mainHand && slot != 45)
+            return;
+
+        Map<Player, SimpleItemData> data = mainHand ? this.mainHand : this.offHand;
+
+        ItemStack packetItem = SpigotConversionUtil.toBukkitItemStack(wrapper.getItem());
+        if (!packetItem.hasItemMeta() || !CustomTag.WEAPON_TITLE.hasString(packetItem)) {
+            data.put(player, null);
+            return;
+        }
+
+        SimpleItemData lastData = data.get(player);
+        if (lastData == null) {
+            data.put(player, new SimpleItemData(slot, packetItem));
+            return;
+        }
+
+        SimpleItemData newData = new SimpleItemData(slot, packetItem);
+        if (newData.isDifferent(lastData)) {
+            data.put(player, newData);
+            return;
+        }
+
+        event.setCancelled(true);
+    }
+
+    public static class SimpleItemData {
+
+        private final int sentToSlot;
+        private final Material type;
+        private final int amount;
+        private String displayName;
+        private List<String> lore;
+        private int customModelData;
+        private int damage;
+
+        public SimpleItemData(int sentToSlot, ItemStack itemStack) {
+            this.sentToSlot = sentToSlot;
+            this.type = itemStack.getType();
+            this.amount = itemStack.getAmount();
+            ItemMeta itemMeta = itemStack.getItemMeta();
+            if (itemMeta == null)
+                return;
+
+            if (itemMeta.hasDisplayName())
+                this.displayName = itemMeta.getDisplayName();
+            if (itemMeta.hasLore())
+                this.lore = itemMeta.getLore();
+            if (itemMeta.hasCustomModelData())
+                this.customModelData = itemMeta.getCustomModelData();
+            if (itemMeta instanceof Damageable damageable)
+                this.damage = damageable.getDamage();
+        }
+
+        public boolean isDifferent(SimpleItemData other) {
+            return sentToSlot != other.sentToSlot || type != other.type || amount != other.amount || customModelData != other.customModelData
+                || damage != other.damage || !Objects.equals(displayName, other.displayName)
+                || !Objects.equals(lore, other.lore);
+        }
+    }
+}

--- a/WeaponMechanics/src/main/resources/WeaponMechanics/config.yml
+++ b/WeaponMechanics/src/main/resources/WeaponMechanics/config.yml
@@ -108,6 +108,11 @@ Disable_Block_Break_Event: false
 # the suggested format. Disabling this makes it much easier for you to make mistakes.
 Strict_Relative_Skins: true
 
+# Enabling this will make it so that Legacy Minecraft clients (v1.21.3 and below)
+# will see the bobbing item fix applied. This should only be used if you intend
+# to support via-backwards for legacy clients.
+Fix_Bobbing_Legacy: false
+
 # These options define how "random" the explosions are. It doesn't effect block
 # regeneration. These effects don't look very pretty on larger explosions, but
 # they improve smaller ones.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Versions of the 2 plugins stored in this repo.
 mechanicsCoreVersion=4.0.4
-weaponMechanicsVersion=4.0.5
+weaponMechanicsVersion=4.0.6-BETA1
 
 # Version of the resource pack
 resourcePackVersion=3.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Versions of the 2 plugins stored in this repo.
 mechanicsCoreVersion=4.0.4
-weaponMechanicsVersion=4.0.6-BETA1
+weaponMechanicsVersion=4.0.6
 
 # Version of the resource pack
 resourcePackVersion=3.0.0


### PR DESCRIPTION
For servers trying to support older clients (<1.21.4), bobbing becomes a major issue. This patch adds:
1. a packet listener that only tries to fix bobbing for clients <1.21.4
2. adds a new config key (see below)

[WeaponMechanics.zip](https://github.com/user-attachments/files/18499905/WeaponMechanics.zip)

Add this to your config.yml to enable this feature
```yaml
# Enabling this will make it so that Legacy Minecraft clients (1.21.3 and below)
# will see the bobbing item fix applied. This should only be used if you intend
# to support via-backwards for legacy clients.
Fix_Bobbing_Legacy: true
```