### PR TITLE
Fix attributes not being applied to items

### DIFF
--- a/MechanicsCore/src/main/java/me/deecaad/core/file/serializers/ItemSerializer.java
+++ b/MechanicsCore/src/main/java/me/deecaad/core/file/serializers/ItemSerializer.java
@@ -332,6 +332,8 @@ public class ItemSerializer implements Serializer<ItemStack> {
             }
         }
 
+        itemStack.setItemMeta(itemMeta);
+
         // Add flags after attributes due to a bug introduced in Spigot 1.20.5, see
         // https://github.com/PaperMC/Paper/issues/10693
         boolean hideFlags = data.of("Hide_Flags").getBool().orElse(false);


### PR DESCRIPTION
Very simple fix - the issue was that we were not setting the modified `ItemMeta` back on the `ItemStack`.

This fixes the `Attributes` sub-section of `Info` not working at all.