### PR TITLE
use mutable map instead of immutable

### DIFF
--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/damage/DamageUtil.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/damage/DamageUtil.java
@@ -1,5 +1,6 @@
 package me.deecaad.weaponmechanics.weapon.damage;
 
+import com.google.common.base.Function;
 import me.deecaad.core.file.Configuration;
 import me.deecaad.core.utils.NumberUtil;
 import me.deecaad.core.utils.RandomUtil;
@@ -37,6 +38,8 @@ import org.bukkit.scoreboard.Team;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.Set;
 
 public class DamageUtil {
@@ -151,7 +154,21 @@ public class DamageUtil {
             }
 
 
-            var entityDamageByEntityEvent = new EntityDamageByEntityEvent(source.getShooter(), victim, cause, bukkitSource.build(), Collections.singletonMap(EntityDamageEvent.DamageModifier.BASE, damage), Collections.singletonMap(EntityDamageEvent.DamageModifier.BASE, it -> it), false);
+            var damageMap = new EnumMap<EntityDamageEvent.DamageModifier, Double>(EntityDamageEvent.DamageModifier.class);
+            damageMap.put(EntityDamageEvent.DamageModifier.BASE, damage);
+
+            var modifierMap = new HashMap<EntityDamageEvent.DamageModifier, Function<? super Double, Double>>();
+            modifierMap.put(EntityDamageEvent.DamageModifier.BASE, it -> it);
+
+            var entityDamageByEntityEvent = new EntityDamageByEntityEvent(
+                    source.getShooter(),
+                    victim,
+                    cause,
+                    bukkitSource.build(),
+                    damageMap,
+                    modifierMap,
+                    false
+            );
             victim.setMetadata("doing-weapon-damage", new LazyMetadataValue(WeaponMechanics.getInstance(), () -> true));
             Bukkit.getPluginManager().callEvent(entityDamageByEntityEvent);
             victim.removeMetadata("doing-weapon-damage", WeaponMechanics.getInstance());


### PR DESCRIPTION
Immutable maps in EntityDamageByEntityEvent causes some error in other plugins, which change damage.
any tries to change damage in EntityDamageByEntityEvent (fired by WeaponMechanics) makes a throw UnsupportedOperationException.
Solution is so simple - use mutable maps instead of immutable when EntityDamageByEntityEvent firing