### PR TITLE
Feature: add incendiary projectile support + small fix in ScopeHandler + /wm reload fix

### DIFF
--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/Projectile.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/Projectile.java
@@ -67,46 +67,66 @@ public class Projectile implements Serializer<Projectile> {
      * @param location the location containing pitch and yaw
      */
     public WeaponProjectile shoot(WeaponProjectile projectile, Location location) {
-        if (mechanics != null) {
-            CastData cast = new CastData(projectile.getShooter(), projectile.getWeaponTitle(), projectile.getWeaponStack());
+        String weaponTitle = projectile.getWeaponTitle();
+        ItemStack weaponStack = projectile.getWeaponStack();
+        
+        if (mechanics != null && weaponTitle != null) {
+            CastData cast = new CastData(projectile.getShooter(), weaponTitle, weaponStack);
             cast.setTargetLocation(() -> projectile.getLocation().toLocation(projectile.getWorld()));
             mechanics.use(cast);
         }
 
-        EntityType type = projectileSettings.getProjectileDisguise();
+        ProjectileSettings settings = projectile.getProjectileSettings();
+        EntityType type = settings.getProjectileDisguise();
+
         if (type != null) {
 
             FakeEntity fakeEntity;
-            Object data = projectileSettings.getDisguiseData();
+            Object data = settings.getDisguiseData();
+            Location spawnLoc = location.clone();
+
             if (type == EntityType.ARMOR_STAND && data != null) {
                 // Armor stand height * eye height multiplier
                 // 1.975 * 0.85 = 1.67875
-                Location offset = new Location(location.getWorld(), 0, -1.67875, 0);
+                Location offset = new Location(spawnLoc.getWorld(), 0, -1.67875, 0);
+                spawnLoc.add(offset);
 
-                // Add the first offset before actually spawning
-                location.add(offset);
-
-                fakeEntity = CompatibilityAPI.getEntityCompatibility().generateFakeEntity(location, type, data);
-
+                fakeEntity = CompatibilityAPI.getEntityCompatibility().generateFakeEntity(spawnLoc, type, data);
                 fakeEntity.setEquipment(EquipmentSlot.HEAD, (ItemStack) data);
                 fakeEntity.setInvisible(true);
-
-                // Set the offset for new packets
                 fakeEntity.setOffset(offset);
             } else {
-                fakeEntity = CompatibilityAPI.getEntityCompatibility().generateFakeEntity(location, type, data);
+                fakeEntity = CompatibilityAPI.getEntityCompatibility().generateFakeEntity(spawnLoc, type, data);
+            }
+
+            Location projectileLocation = location.clone();
+
+            if (settings.isIncendiaryProjectile() && !isInWaterOrWaterlogged(projectileLocation)) {
+                fakeEntity.setOnFire(true);
             }
 
             projectile.spawnDisguise(fakeEntity);
         }
 
-        // Handle explosions
-        Explosion explosion = WeaponMechanics.getInstance().getWeaponConfigurations().getObject(projectile.getWeaponTitle() + ".Explosion", Explosion.class);
-        if (explosion != null)
-            explosion.handleExplosion(projectile.getShooter(), projectile, ExplosionTrigger.SPAWN);
+        if (weaponTitle != null) {
+            // Handle explosions
+            Explosion explosion = WeaponMechanics.getInstance().getWeaponConfigurations().getObject(weaponTitle + ".Explosion", Explosion.class);
+            if (explosion != null)
+                explosion.handleExplosion(projectile.getShooter(), projectile, ExplosionTrigger.SPAWN);
+        }
 
         WeaponMechanics.getInstance().getProjectileSpawner().spawn(projectile);
         return projectile;
+    }
+
+    private boolean isInWaterOrWaterlogged(Location loc) {
+        var block = loc.getBlock();
+
+        if (block.getType().name().equals("BUBBLE_COLUMN")) return true;
+        if (block.isLiquid()) return true;
+
+        var data = block.getBlockData();
+        return (data instanceof org.bukkit.block.data.Waterlogged wl) && wl.isWaterlogged();
     }
 
     /**

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/ProjectileSettings.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/ProjectileSettings.java
@@ -37,6 +37,8 @@ public class ProjectileSettings implements Serializer<ProjectileSettings>, Clone
     private int maximumAliveTicks;
     private double maximumTravelDistance;
     private double size;
+    private boolean incendiaryProjectile;
+    private boolean extinguishInWater = true;
 
     /**
      * Empty constructor to be used as serializer
@@ -47,7 +49,7 @@ public class ProjectileSettings implements Serializer<ProjectileSettings>, Clone
     public ProjectileSettings(EntityType projectileDisguise, Object disguiseData, double gravity,
         boolean removeAtMinimumSpeed, double minimumSpeed, boolean removeAtMaximumSpeed, double maximumSpeed,
         double decrease, double decreaseInWater, double decreaseWhenRainingOrSnowing, boolean disableEntityCollisions,
-        int maximumAliveTicks, double maximumTravelDistance, double size) {
+        int maximumAliveTicks, double maximumTravelDistance, double size, boolean incendiaryProjectile, boolean extinguishInWater) {
         this.projectileDisguise = projectileDisguise;
         this.disguiseData = disguiseData;
         this.gravity = gravity;
@@ -62,6 +64,8 @@ public class ProjectileSettings implements Serializer<ProjectileSettings>, Clone
         this.maximumAliveTicks = maximumAliveTicks;
         this.maximumTravelDistance = maximumTravelDistance;
         this.size = size;
+        this.incendiaryProjectile = incendiaryProjectile;
+        this.extinguishInWater = extinguishInWater;
     }
 
     /**
@@ -221,6 +225,28 @@ public class ProjectileSettings implements Serializer<ProjectileSettings>, Clone
         this.size = size;
     }
 
+    /**
+     * @return whether the projectile is on fire or not
+     */
+    public boolean isIncendiaryProjectile() {
+        return incendiaryProjectile;
+    }
+
+    public void setIncendiaryProjectile(boolean incendiaryProjectile) {
+        this.incendiaryProjectile = incendiaryProjectile;
+    }
+
+    /**
+     * @return whether the projectile should be extinguished in water
+     */
+    public boolean isExtinguishInWater() {
+        return extinguishInWater;
+    }
+
+    public void setExtinguishInWater(boolean extinguishInWater) {
+        this.extinguishInWater = extinguishInWater;
+    }
+
     @Override
     public String getKeyword() {
         return "Projectile_Settings";
@@ -297,10 +323,12 @@ public class ProjectileSettings implements Serializer<ProjectileSettings>, Clone
         int maximumAliveTicks = data.of("Maximum_Alive_Ticks").assertRange(0, null).getInt().orElse(600);
         double maximumTravelDistance = data.of("Maximum_Travel_Distance").assertRange(0.0, null).getDouble().orElse(-1.0);
         double size = data.of("Size").assertRange(0.0, null).getDouble().orElse(0.1);
+        boolean incendiaryProjectile = data.of("Incendiary_Projectile").getBool().orElse(false);
+        boolean extinguishInWater = data.of("Extinguish_In_Water").getBool().orElse(true);
 
         return new ProjectileSettings(projectileType, disguiseData, gravity, removeAtMinimumSpeed, minimumSpeed,
             removeAtMaximumSpeed, maximumSpeed, decrease, decreaseInWater, decreaseWhenRainingOrSnowing,
-            disableEntityCollisions, maximumAliveTicks, maximumTravelDistance, size);
+            disableEntityCollisions, maximumAliveTicks, maximumTravelDistance, size, incendiaryProjectile, extinguishInWater);
     }
 
     @Override

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/WeaponProjectile.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/WeaponProjectile.java
@@ -327,6 +327,35 @@ public class WeaponProjectile extends AProjectile {
         return rolling;
     }
 
+    private static boolean isWater(Block block) {
+        if (block == null) return false;
+
+        String name = block.getType().name();
+        if (name.equals("BUBBLE_COLUMN")) return true;
+
+        if (block.isLiquid()) {
+            return name.equals("WATER") || name.equals("STATIONARY_WATER") || name.endsWith("_WATER");
+        }
+
+        var data = block.getBlockData();
+        return (data instanceof org.bukkit.block.data.Waterlogged wl) && wl.isWaterlogged();
+    }
+
+    private void tryExtinguishInWater(Block block) {
+        if (!isWater(block)) return;
+        if (!projectileSettings.isExtinguishInWater()) return;
+
+        var disguise = getDisguise();
+        if (disguise != null && disguise.isOnFire()) {
+            disguise.setOnFire(false);
+            disguise.updateMeta();
+        }
+
+        if (projectileSettings.isIncendiaryProjectile()) {
+            getProjectileSettings().setIncendiaryProjectile(false);
+        }
+    }
+
     @Override
     public boolean updatePosition() {
 
@@ -335,6 +364,10 @@ public class WeaponProjectile extends AProjectile {
             // Remove projectile if next location would be in unloaded chunk
             return true;
         }
+
+        tryExtinguishInWater(getCurrentBlock());
+        Block nextBlock = possibleNextLocation.toLocation(getWorld()).getBlock();
+        tryExtinguishInWater(nextBlock);
 
         if (stickedData != null) {
             Vector newLocation = stickedData.getNewLocation();
@@ -388,8 +421,11 @@ public class WeaponProjectile extends AProjectile {
             onCollide(hit);
 
             // We only want to let onCollide to be called onLiquid hits
-            if (hit instanceof BlockTraceResult blockHit && blockHit.getBlock().isLiquid()) {
-                continue;
+            if (hit instanceof BlockTraceResult blockHit) {
+                tryExtinguishInWater(blockHit.getBlock());
+                if (blockHit.getBlock().isLiquid()) {
+                    continue;
+                }
             }
 
             // Returned true and that most likely means that block hit was cancelled, skipping...

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/scope/ScopeHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/scope/ScopeHandler.java
@@ -283,7 +283,7 @@ public class ScopeHandler implements IValidator, TriggerListener {
             player.isFlying(),
             player.getAllowFlight(),
             player.getGameMode() == GameMode.CREATIVE,
-            player.getFlySpeed(),
+            player.getFlySpeed() / 2,
             player.getWalkSpeed() / 2 // divide by 2, since spigot multiplies this by 2
         );
 

--- a/weaponmechanics-core/src/main/kotlin/me/deecaad/weaponmechanics/WeaponMechanicsCommand.kt
+++ b/weaponmechanics-core/src/main/kotlin/me/deecaad/weaponmechanics/WeaponMechanicsCommand.kt
@@ -1393,7 +1393,7 @@ object WeaponMechanicsCommand {
             ProjectileSettings(
                 entity, null,
                 gravity, false, -1.0, false,
-                -1.0, 0.99, 0.96, 0.98, false, 600, -1.0, 0.1,
+                -1.0, 0.99, 0.96, 0.98, false, 600, -1.0, 0.1, false, false
             )
         val projectile = Projectile(projectileSettings, null, null, null, null)
         projectile.shoot(sender, sender.eyeLocation, sender.location.direction.multiply(speed), null, null, null)

--- a/weaponmechanics-core/src/main/kotlin/me/deecaad/weaponmechanics/WeaponMechanicsCommand.kt
+++ b/weaponmechanics-core/src/main/kotlin/me/deecaad/weaponmechanics/WeaponMechanicsCommand.kt
@@ -105,8 +105,13 @@ import kotlin.math.sin
 object WeaponMechanicsCommand {
     const val WIKI: String = "https://cjcrafter.gitbook.io/weaponmechanics/"
 
+    private val registered = java.util.concurrent.atomic.AtomicBoolean(false)
+
     @JvmStatic
     fun registerCommands() {
+
+        if (!registered.compareAndSet(false, true)) return
+
         val weaponDataMapArgument =
             CustomMapArgument(
                 "data",


### PR DESCRIPTION
Two new configurations:
- Incendiary_Projectile, set's projectiles ablaze
- Extinguish_In_Water, extinguishes projectiles on contact with water

Fixed:
- when players scope, their flying speed was doubled
- prevented duplicate command registration during `/wm reload` by making command registration idempotent
- avoided re-registering commands during reload by default to prevent unnecessary heavy reload behavior