### PR TITLE
fix: load WeaponMechanics before MythicMobs

### DIFF
--- a/weaponmechanics-build/build.gradle.kts
+++ b/weaponmechanics-build/build.gradle.kts
@@ -34,7 +34,7 @@ paperPluginYaml {
         server("WorldEdit", required = false)
         server("WorldGuard", required = false)
         server("PlaceholderAPI", required = false)
-        server("MythicMobs", required = false)
+        server("MythicMobs", required = false, load = PaperPluginYaml.Load.BEFORE)
         server("Geyser-Spigot", required = false)
         server("Vivecraft-Spigot-Extension", required = false)
     }


### PR DESCRIPTION
I noticed that the CustomMechanic feature in MythicMobs, provided by WM, was not working and was returning a NULL error.
Changing the order in which the plugins are loaded resolves the issue.
I applied the same fix to MechanicsCore as well.