### PR TITLE
feat: add ADS_Speed config for scope settling time

### DIFF
--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/compatibility/IWeaponCompatibility.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/compatibility/IWeaponCompatibility.java
@@ -1,5 +1,6 @@
 package me.deecaad.weaponmechanics.compatibility;
 
+import com.cjcrafter.foliascheduler.TaskImplementation;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 
@@ -40,4 +41,20 @@ public interface IWeaponCompatibility {
      * @param killer The killer
      */
     void setKiller(LivingEntity victim, Player killer);
+
+    /**
+     * Triggers the vanilla attack cooldown animation (item drops down then rises back up) for the given
+     * player, with a duration matched to {@code durationTicks}. This is used to give visual feedback
+     * during ADS settling.
+     *
+     * <p>Internally this resets the NMS {@code attackStrengthTicker} to 0 and temporarily modifies the
+     * {@code ATTACK_SPEED} attribute so the animation completes in exactly {@code durationTicks} ticks.
+     *
+     * @param player       the player to show the animation to
+     * @param durationTicks how many ticks the animation should take to complete
+     * @return the scheduled task that will restore the attack speed attribute when the animation ends;
+     *     store this in {@link me.deecaad.weaponmechanics.wrappers.ZoomData#setAdsSettleTask} so it
+     *     can be cancelled if the player exits scope early
+     */
+    TaskImplementation<Void> playAdsSettleAnimation(Player player, int durationTicks);
 }

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/scope/ScopeHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/scope/ScopeHandler.java
@@ -1,5 +1,6 @@
 package me.deecaad.weaponmechanics.weapon.scope;
 
+import com.cjcrafter.foliascheduler.TaskImplementation;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.protocol.potion.PotionTypes;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityEffect;
@@ -13,6 +14,7 @@ import me.deecaad.core.placeholder.PlaceholderData;
 import me.deecaad.core.placeholder.PlaceholderMessage;
 import me.deecaad.core.utils.NumberUtil;
 import me.deecaad.weaponmechanics.WeaponMechanics;
+import me.deecaad.weaponmechanics.compatibility.WeaponCompatibilityAPI;
 import me.deecaad.weaponmechanics.weapon.WeaponHandler;
 import me.deecaad.weaponmechanics.weapon.trigger.Trigger;
 import me.deecaad.weaponmechanics.weapon.trigger.TriggerListener;
@@ -193,6 +195,17 @@ public class ScopeHandler implements IValidator, TriggerListener {
                 if (weaponScopeEvent.getMechanics() != null)
                     weaponScopeEvent.getMechanics().use(new CastData(entity, weaponTitle, weaponStack));
 
+                // Restart ADS settling on each zoom stack (player is re-adjusting their aim)
+                int adsSpeedMillis = config.getInt(weaponTitle + ".Scope.ADS_Speed");
+                if (adsSpeedMillis > 0 && entity instanceof Player player) {
+                    int adsSpeedTicks = adsSpeedMillis / 50;
+                    zoomData.stopSettling(); // cancel previous settling first
+                    zoomData.startSettling(adsSpeedMillis);
+                    TaskImplementation<Void> task = WeaponCompatibilityAPI.getWeaponCompatibility()
+                        .playAdsSettleAnimation(player, adsSpeedTicks);
+                    zoomData.setAdsSettleTask(task);
+                }
+
                 return true;
             } else {
                 WeaponMechanics.getInstance().getDebugger().warning("For some reason zoom in was called on entity when it shouldn't have.",
@@ -228,6 +241,16 @@ public class ScopeHandler implements IValidator, TriggerListener {
         HandData handData = slot == EquipmentSlot.HAND ? entityWrapper.getMainHandData() : entityWrapper.getOffHandData();
         handData.setLastScopeTime(System.currentTimeMillis());
 
+        // ADS settling: temporarily keep hipfire accuracy until the timer expires
+        int adsSpeedMillis = config.getInt(weaponTitle + ".Scope.ADS_Speed");
+        if (adsSpeedMillis > 0 && entity instanceof Player player) {
+            int adsSpeedTicks = adsSpeedMillis / 50;
+            zoomData.startSettling(adsSpeedMillis);
+            TaskImplementation<Void> task = WeaponCompatibilityAPI.getWeaponCompatibility()
+                .playAdsSettleAnimation(player, adsSpeedTicks);
+            zoomData.setAdsSettleTask(task);
+        }
+
         return true;
     }
 
@@ -239,6 +262,9 @@ public class ScopeHandler implements IValidator, TriggerListener {
         if (!zoomData.isZooming())
             return false;
         LivingEntity entity = entityWrapper.getEntity();
+
+        // Stop any active ADS settling when zooming out
+        zoomData.stopSettling();
 
         MechanicManager zoomOffMechanics = WeaponMechanics.getInstance().getWeaponConfigurations().getObject(weaponTitle + ".Scope.Zoom_Off.Mechanics", MechanicManager.class);
 
@@ -371,6 +397,12 @@ public class ScopeHandler implements IValidator, TriggerListener {
         if (shootDelayAfterScope != 0) {
             // Convert to millis
             configuration.set(data.getKey() + ".Shoot_Delay_After_Scope", shootDelayAfterScope * 50);
+        }
+
+        int adsSpeed = data.of("ADS_Speed").getInt().orElse(0);
+        if (adsSpeed != 0) {
+            // Convert to millis (same pattern as Shoot_Delay_After_Scope)
+            configuration.set(data.getKey() + ".ADS_Speed", adsSpeed * 50);
         }
     }
 }

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/shoot/AModifyWhen.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/shoot/AModifyWhen.java
@@ -3,6 +3,7 @@ package me.deecaad.weaponmechanics.weapon.shoot;
 import me.deecaad.core.file.Serializer;
 import me.deecaad.weaponmechanics.wrappers.EntityWrapper;
 import me.deecaad.weaponmechanics.wrappers.PlayerWrapper;
+import me.deecaad.weaponmechanics.wrappers.ZoomData;
 
 public abstract class AModifyWhen implements Serializer<AModifyWhen> {
 
@@ -53,8 +54,13 @@ public abstract class AModifyWhen implements Serializer<AModifyWhen> {
         if (always != null) {
             tempNumber = always.applyTo(tempNumber);
         }
-        if (zooming != null && (entityWrapper.getMainHandData().getZoomData().isZooming() || entityWrapper.getOffHandData().getZoomData().isZooming())) {
-            tempNumber = zooming.applyTo(tempNumber);
+        if (zooming != null) {
+            ZoomData mainZoom = entityWrapper.getMainHandData().getZoomData();
+            ZoomData offZoom = entityWrapper.getOffHandData().getZoomData();
+            // Skip the Zooming modifier while ADS is still settling (player has hipfire accuracy)
+            if ((mainZoom.isZooming() || offZoom.isZooming()) && !mainZoom.isSettling() && !offZoom.isSettling()) {
+                tempNumber = zooming.applyTo(tempNumber);
+            }
         }
         if (sneaking != null && entityWrapper.isSneaking()) {
             tempNumber = sneaking.applyTo(tempNumber);

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/wrappers/ZoomData.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/wrappers/ZoomData.java
@@ -1,11 +1,16 @@
 package me.deecaad.weaponmechanics.wrappers;
 
+import com.cjcrafter.foliascheduler.TaskImplementation;
 import me.deecaad.core.mechanics.CastData;
 import me.deecaad.core.mechanics.MechanicManager;
 import me.deecaad.weaponmechanics.WeaponMechanics;
 import me.deecaad.weaponmechanics.weapon.scope.ScopeHandler;
 import me.deecaad.weaponmechanics.weapon.weaponevents.WeaponScopeEvent;
 import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
@@ -15,12 +20,23 @@ import org.vivecraft.api.data.VRPose;
 
 public class ZoomData {
 
+    /**
+     * The NamespacedKey used for the temporary attack speed attribute modifier applied during ADS settling.
+     * Stored here so both ZoomData and the compatibility layer share the same key.
+     */
+    public static final NamespacedKey ADS_SPEED_MODIFIER_KEY = new NamespacedKey("weaponmechanics", "ads_speed");
+
     private final HandData handData;
     private double zoomAmount;
     private int zoomStacks;
     private boolean zoomNightVision;
     private ItemStack scopeWeaponStack;
     private String scopeWeaponTitle;
+
+    /** System.currentTimeMillis() timestamp when ADS settling ends. 0 = not settling. */
+    private long scopeSettleEndTime = 0;
+    /** Scheduled task that removes the ADS speed attribute modifier when settling completes. */
+    private TaskImplementation<Void> adsSettleTask;
 
     public ZoomData(HandData handData) {
         this.handData = handData;
@@ -100,7 +116,60 @@ public class ZoomData {
         this.zoomNightVision = zoomNightVision;
     }
 
+    /**
+     * @return {@code true} if the ADS settling timer is currently active (scope was just entered and
+     *     accuracy has not yet transitioned to full ADS accuracy).
+     */
+    public boolean isSettling() {
+        return scopeSettleEndTime != 0 && System.currentTimeMillis() < scopeSettleEndTime;
+    }
+
+    /**
+     * Starts the ADS settling timer. Call this when a player enters scope.
+     *
+     * @param durationMillis how long (in milliseconds) until full ADS accuracy is reached
+     */
+    public void startSettling(long durationMillis) {
+        this.scopeSettleEndTime = System.currentTimeMillis() + durationMillis;
+    }
+
+    /**
+     * Stores the task scheduled to remove the ADS speed modifier at the end of settling.
+     * Call {@link #stopSettling()} to cancel it early.
+     */
+    public void setAdsSettleTask(TaskImplementation<Void> task) {
+        this.adsSettleTask = task;
+    }
+
+    /**
+     * Stops ADS settling immediately: cancels the pending restore task and removes the temporary
+     * attack speed modifier from the player. Safe to call when already not settling.
+     */
+    public void stopSettling() {
+        this.scopeSettleEndTime = 0;
+        if (adsSettleTask != null) {
+            adsSettleTask.cancel();
+            adsSettleTask = null;
+        }
+        // Remove the temporary attack speed modifier if it is still on the player
+        EntityWrapper entityWrapper = handData.getEntityWrapper();
+        if (entityWrapper.getEntity() instanceof Player player) {
+            AttributeInstance attr = player.getAttribute(Attribute.ATTACK_SPEED);
+            if (attr != null) {
+                for (AttributeModifier mod : new java.util.ArrayList<>(attr.getModifiers())) {
+                    if (ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                        attr.removeModifier(mod);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
     public void ifZoomingForceZoomOut() {
+        // Stop any active ADS settling (cancels task + removes attribute modifier)
+        stopSettling();
+
         if (isZooming()) {
 
             // IF player is in VR this happens

--- a/weaponmechanics-platforms/paper/v1_21_R2/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R2.java
+++ b/weaponmechanics-platforms/paper/v1_21_R2/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R2.java
@@ -1,5 +1,8 @@
 package me.deecaad.weaponmechanics.compatibility;
 
+import com.cjcrafter.foliascheduler.TaskImplementation;
+import me.deecaad.weaponmechanics.WeaponMechanics;
+import me.deecaad.weaponmechanics.wrappers.ZoomData;
 import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageSources;
@@ -7,10 +10,14 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.PositionMoveRotation;
 import net.minecraft.world.entity.Relative;
 import net.minecraft.world.phys.Vec3;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.craftbukkit.entity.CraftLivingEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -71,5 +78,40 @@ public class v1_21_R2 implements IWeaponCompatibility {
     @Override
     public void setKiller(org.bukkit.entity.LivingEntity victim, Player killer) {
         ((CraftLivingEntity) victim).getHandle().lastHurtByMob = ((CraftPlayer) killer).getHandle();
+    }
+
+    @Override
+    public TaskImplementation<Void> playAdsSettleAnimation(Player player, int durationTicks) {
+        // Reset the attack strength ticker to trigger the item-drop animation client-side
+        ((CraftPlayer) player).getHandle().attackStrengthTicker = 0;
+
+        // Temporarily set attack speed so the animation finishes in exactly durationTicks ticks.
+        // Formula: fullRaiseTicks = 1.0 / attackSpeed * 20  =>  attackSpeed = 20.0 / durationTicks
+        AttributeInstance attr = player.getAttribute(Attribute.ATTACK_SPEED);
+        if (attr != null) {
+            double requiredSpeed = 20.0 / Math.max(1, durationTicks);
+            double addValue = requiredSpeed - attr.getBaseValue();
+            // Remove any leftover modifier from a previous scope cycle first
+            for (AttributeModifier mod : new ArrayList<>(attr.getModifiers())) {
+                if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                    attr.removeModifier(mod);
+                    break;
+                }
+            }
+            attr.addModifier(new AttributeModifier(ZoomData.ADS_SPEED_MODIFIER_KEY, addValue, AttributeModifier.Operation.ADD_NUMBER));
+        }
+
+        // Schedule removal of the modifier once the animation is done
+        return WeaponMechanics.getInstance().getFoliaScheduler().entity(player).runDelayed(() -> {
+            AttributeInstance a = player.getAttribute(Attribute.ATTACK_SPEED);
+            if (a != null) {
+                for (AttributeModifier mod : new ArrayList<>(a.getModifiers())) {
+                    if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                        a.removeModifier(mod);
+                        break;
+                    }
+                }
+            }
+        }, (long) durationTicks);
     }
 }

--- a/weaponmechanics-platforms/paper/v1_21_R3/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R3.java
+++ b/weaponmechanics-platforms/paper/v1_21_R3/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R3.java
@@ -1,5 +1,8 @@
 package me.deecaad.weaponmechanics.compatibility;
 
+import com.cjcrafter.foliascheduler.TaskImplementation;
+import me.deecaad.weaponmechanics.WeaponMechanics;
+import me.deecaad.weaponmechanics.wrappers.ZoomData;
 import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageSources;
@@ -7,10 +10,14 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.PositionMoveRotation;
 import net.minecraft.world.entity.Relative;
 import net.minecraft.world.phys.Vec3;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.craftbukkit.entity.CraftLivingEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -71,5 +78,35 @@ public class v1_21_R3 implements IWeaponCompatibility {
     @Override
     public void setKiller(org.bukkit.entity.LivingEntity victim, Player killer) {
         ((CraftLivingEntity) victim).getHandle().lastHurtByMob = ((CraftPlayer) killer).getHandle();
+    }
+
+    @Override
+    public TaskImplementation<Void> playAdsSettleAnimation(Player player, int durationTicks) {
+        ((CraftPlayer) player).getHandle().attackStrengthTicker = 0;
+
+        AttributeInstance attr = player.getAttribute(Attribute.ATTACK_SPEED);
+        if (attr != null) {
+            double requiredSpeed = 20.0 / Math.max(1, durationTicks);
+            double addValue = requiredSpeed - attr.getBaseValue();
+            for (AttributeModifier mod : new ArrayList<>(attr.getModifiers())) {
+                if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                    attr.removeModifier(mod);
+                    break;
+                }
+            }
+            attr.addModifier(new AttributeModifier(ZoomData.ADS_SPEED_MODIFIER_KEY, addValue, AttributeModifier.Operation.ADD_NUMBER));
+        }
+
+        return WeaponMechanics.getInstance().getFoliaScheduler().entity(player).runDelayed(() -> {
+            AttributeInstance a = player.getAttribute(Attribute.ATTACK_SPEED);
+            if (a != null) {
+                for (AttributeModifier mod : new ArrayList<>(a.getModifiers())) {
+                    if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                        a.removeModifier(mod);
+                        break;
+                    }
+                }
+            }
+        }, (long) durationTicks);
     }
 }

--- a/weaponmechanics-platforms/paper/v1_21_R4/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R4.java
+++ b/weaponmechanics-platforms/paper/v1_21_R4/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R4.java
@@ -1,5 +1,8 @@
 package me.deecaad.weaponmechanics.compatibility;
 
+import com.cjcrafter.foliascheduler.TaskImplementation;
+import me.deecaad.weaponmechanics.WeaponMechanics;
+import me.deecaad.weaponmechanics.wrappers.ZoomData;
 import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageSources;
@@ -7,10 +10,14 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.PositionMoveRotation;
 import net.minecraft.world.entity.Relative;
 import net.minecraft.world.phys.Vec3;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.craftbukkit.entity.CraftLivingEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -71,5 +78,35 @@ public class v1_21_R4 implements IWeaponCompatibility {
     @Override
     public void setKiller(org.bukkit.entity.LivingEntity victim, Player killer) {
         ((CraftLivingEntity) victim).getHandle().setLastHurtByPlayer(((CraftPlayer) killer).getHandle(), 100);
+    }
+
+    @Override
+    public TaskImplementation<Void> playAdsSettleAnimation(Player player, int durationTicks) {
+        ((CraftPlayer) player).getHandle().attackStrengthTicker = 0;
+
+        AttributeInstance attr = player.getAttribute(Attribute.ATTACK_SPEED);
+        if (attr != null) {
+            double requiredSpeed = 20.0 / Math.max(1, durationTicks);
+            double addValue = requiredSpeed - attr.getBaseValue();
+            for (AttributeModifier mod : new ArrayList<>(attr.getModifiers())) {
+                if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                    attr.removeModifier(mod);
+                    break;
+                }
+            }
+            attr.addModifier(new AttributeModifier(ZoomData.ADS_SPEED_MODIFIER_KEY, addValue, AttributeModifier.Operation.ADD_NUMBER));
+        }
+
+        return WeaponMechanics.getInstance().getFoliaScheduler().entity(player).runDelayed(() -> {
+            AttributeInstance a = player.getAttribute(Attribute.ATTACK_SPEED);
+            if (a != null) {
+                for (AttributeModifier mod : new ArrayList<>(a.getModifiers())) {
+                    if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                        a.removeModifier(mod);
+                        break;
+                    }
+                }
+            }
+        }, (long) durationTicks);
     }
 }

--- a/weaponmechanics-platforms/paper/v1_21_R5/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R5.java
+++ b/weaponmechanics-platforms/paper/v1_21_R5/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R5.java
@@ -1,5 +1,8 @@
 package me.deecaad.weaponmechanics.compatibility;
 
+import com.cjcrafter.foliascheduler.TaskImplementation;
+import me.deecaad.weaponmechanics.WeaponMechanics;
+import me.deecaad.weaponmechanics.wrappers.ZoomData;
 import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageSources;
@@ -7,10 +10,14 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.PositionMoveRotation;
 import net.minecraft.world.entity.Relative;
 import net.minecraft.world.phys.Vec3;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.craftbukkit.entity.CraftLivingEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -71,5 +78,35 @@ public class v1_21_R5 implements IWeaponCompatibility {
     @Override
     public void setKiller(org.bukkit.entity.LivingEntity victim, Player killer) {
         ((CraftLivingEntity) victim).getHandle().setLastHurtByPlayer(((CraftPlayer) killer).getHandle(), 100);
+    }
+
+    @Override
+    public TaskImplementation<Void> playAdsSettleAnimation(Player player, int durationTicks) {
+        ((CraftPlayer) player).getHandle().attackStrengthTicker = 0;
+
+        AttributeInstance attr = player.getAttribute(Attribute.ATTACK_SPEED);
+        if (attr != null) {
+            double requiredSpeed = 20.0 / Math.max(1, durationTicks);
+            double addValue = requiredSpeed - attr.getBaseValue();
+            for (AttributeModifier mod : new ArrayList<>(attr.getModifiers())) {
+                if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                    attr.removeModifier(mod);
+                    break;
+                }
+            }
+            attr.addModifier(new AttributeModifier(ZoomData.ADS_SPEED_MODIFIER_KEY, addValue, AttributeModifier.Operation.ADD_NUMBER));
+        }
+
+        return WeaponMechanics.getInstance().getFoliaScheduler().entity(player).runDelayed(() -> {
+            AttributeInstance a = player.getAttribute(Attribute.ATTACK_SPEED);
+            if (a != null) {
+                for (AttributeModifier mod : new ArrayList<>(a.getModifiers())) {
+                    if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                        a.removeModifier(mod);
+                        break;
+                    }
+                }
+            }
+        }, (long) durationTicks);
     }
 }

--- a/weaponmechanics-platforms/paper/v1_21_R6/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R6.java
+++ b/weaponmechanics-platforms/paper/v1_21_R6/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R6.java
@@ -1,5 +1,8 @@
 package me.deecaad.weaponmechanics.compatibility;
 
+import com.cjcrafter.foliascheduler.TaskImplementation;
+import me.deecaad.weaponmechanics.WeaponMechanics;
+import me.deecaad.weaponmechanics.wrappers.ZoomData;
 import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageSources;
@@ -7,10 +10,14 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.PositionMoveRotation;
 import net.minecraft.world.entity.Relative;
 import net.minecraft.world.phys.Vec3;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.craftbukkit.entity.CraftLivingEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -71,5 +78,35 @@ public class v1_21_R6 implements IWeaponCompatibility {
     @Override
     public void setKiller(org.bukkit.entity.LivingEntity victim, Player killer) {
         ((CraftLivingEntity) victim).getHandle().setLastHurtByPlayer(((CraftPlayer) killer).getHandle(), 100);
+    }
+
+    @Override
+    public TaskImplementation<Void> playAdsSettleAnimation(Player player, int durationTicks) {
+        ((CraftPlayer) player).getHandle().attackStrengthTicker = 0;
+
+        AttributeInstance attr = player.getAttribute(Attribute.ATTACK_SPEED);
+        if (attr != null) {
+            double requiredSpeed = 20.0 / Math.max(1, durationTicks);
+            double addValue = requiredSpeed - attr.getBaseValue();
+            for (AttributeModifier mod : new ArrayList<>(attr.getModifiers())) {
+                if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                    attr.removeModifier(mod);
+                    break;
+                }
+            }
+            attr.addModifier(new AttributeModifier(ZoomData.ADS_SPEED_MODIFIER_KEY, addValue, AttributeModifier.Operation.ADD_NUMBER));
+        }
+
+        return WeaponMechanics.getInstance().getFoliaScheduler().entity(player).runDelayed(() -> {
+            AttributeInstance a = player.getAttribute(Attribute.ATTACK_SPEED);
+            if (a != null) {
+                for (AttributeModifier mod : new ArrayList<>(a.getModifiers())) {
+                    if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                        a.removeModifier(mod);
+                        break;
+                    }
+                }
+            }
+        }, (long) durationTicks);
     }
 }

--- a/weaponmechanics-platforms/paper/v1_21_R7/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R7.java
+++ b/weaponmechanics-platforms/paper/v1_21_R7/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R7.java
@@ -1,5 +1,8 @@
 package me.deecaad.weaponmechanics.compatibility;
 
+import com.cjcrafter.foliascheduler.TaskImplementation;
+import me.deecaad.weaponmechanics.WeaponMechanics;
+import me.deecaad.weaponmechanics.wrappers.ZoomData;
 import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageSources;
@@ -7,10 +10,14 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.PositionMoveRotation;
 import net.minecraft.world.entity.Relative;
 import net.minecraft.world.phys.Vec3;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.craftbukkit.entity.CraftLivingEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -71,5 +78,35 @@ public class v1_21_R7 implements IWeaponCompatibility {
     @Override
     public void setKiller(org.bukkit.entity.LivingEntity victim, Player killer) {
         ((CraftLivingEntity) victim).getHandle().setLastHurtByPlayer(((CraftPlayer) killer).getHandle(), 100);
+    }
+
+    @Override
+    public TaskImplementation<Void> playAdsSettleAnimation(Player player, int durationTicks) {
+        ((CraftPlayer) player).getHandle().attackStrengthTicker = 0;
+
+        AttributeInstance attr = player.getAttribute(Attribute.ATTACK_SPEED);
+        if (attr != null) {
+            double requiredSpeed = 20.0 / Math.max(1, durationTicks);
+            double addValue = requiredSpeed - attr.getBaseValue();
+            for (AttributeModifier mod : new ArrayList<>(attr.getModifiers())) {
+                if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                    attr.removeModifier(mod);
+                    break;
+                }
+            }
+            attr.addModifier(new AttributeModifier(ZoomData.ADS_SPEED_MODIFIER_KEY, addValue, AttributeModifier.Operation.ADD_NUMBER));
+        }
+
+        return WeaponMechanics.getInstance().getFoliaScheduler().entity(player).runDelayed(() -> {
+            AttributeInstance a = player.getAttribute(Attribute.ATTACK_SPEED);
+            if (a != null) {
+                for (AttributeModifier mod : new ArrayList<>(a.getModifiers())) {
+                    if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                        a.removeModifier(mod);
+                        break;
+                    }
+                }
+            }
+        }, (long) durationTicks);
     }
 }


### PR DESCRIPTION
## Summary

- Adds a new per-weapon `Scope.ADS_Speed` config option (in ticks). When a player scopes in, a settling timer starts during which the weapon retains **hipfire-level accuracy** (the `Zooming` spread modifier is suppressed).
- After the timer expires, full ADS accuracy kicks in normally.
- During settling, the **vanilla attack-cooldown animation** plays (item drops and rises back up), with timing synced to `ADS_Speed`, giving clear visual feedback.

## How it works

The animation is driven by resetting the NMS `attackStrengthTicker` to `0` and temporarily adding an `ATTACK_SPEED` attribute modifier so the rise completes in exactly `ADS_Speed` ticks (`attackSpeed = 20.0 / durationTicks`). The modifier is removed automatically when settling ends or when the player exits scope early.

## Config example

```yaml
Scope:
  Trigger:
    Main_Hand: LEFT_CLICK
  Zoom_Amount: 2.0
  ADS_Speed: 15  # 750ms settling period before full ADS accuracy
```

## Files changed

| File | Change |
|------|--------|
| `ZoomData.java` | Settling state: `isSettling`, `startSettling`, `stopSettling`, task ref |
| `AModifyWhen.java` | Skip `Zooming` modifier while `isSettling()` |
| `ScopeHandler.java` | Read/validate `ADS_Speed`, trigger settling on zoom in/out |
| `IWeaponCompatibility.java` | New `playAdsSettleAnimation(Player, int)` method |
| `v1_21_R2` – `v1_21_R7` | NMS implementation of `playAdsSettleAnimation` |

## Test plan

- Configure a weapon with `ADS_Speed: 20` (1 second)
- Scope in and immediately shoot — spread should be at hipfire level
- Wait 1 second, shoot — spread should be reduced (full ADS accuracy)
- Scope in then immediately scope out — animation stops, no leftover attribute modifier
- Test with zoom-stacking weapons — settling re-triggers on each stack