### PR TITLE
feat: add ADS_Speed config for scope settling time

### DIFF
--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/compatibility/IWeaponCompatibility.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/compatibility/IWeaponCompatibility.java
@@ -1,5 +1,6 @@
 package me.deecaad.weaponmechanics.compatibility;
 
+import com.cjcrafter.foliascheduler.TaskImplementation;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 
@@ -40,4 +41,20 @@ public interface IWeaponCompatibility {
      * @param killer The killer
      */
     void setKiller(LivingEntity victim, Player killer);
+
+    /**
+     * Triggers the vanilla attack cooldown animation (item drops down then rises back up) for the given
+     * player, with a duration matched to {@code durationTicks}. This is used to give visual feedback
+     * during ADS settling.
+     *
+     * <p>Internally this resets the NMS {@code attackStrengthTicker} to 0 and temporarily modifies the
+     * {@code ATTACK_SPEED} attribute so the animation completes in exactly {@code durationTicks} ticks.
+     *
+     * @param player       the player to show the animation to
+     * @param durationTicks how many ticks the animation should take to complete
+     * @return the scheduled task that will restore the attack speed attribute when the animation ends;
+     *     store this in {@link me.deecaad.weaponmechanics.wrappers.ZoomData#setAdsSettleTask} so it
+     *     can be cancelled if the player exits scope early
+     */
+    TaskImplementation<Void> playAdsSettleAnimation(Player player, int durationTicks);
 }

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/HitHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/HitHandler.java
@@ -16,6 +16,7 @@ import me.deecaad.weaponmechanics.weapon.damage.ProjectileDamageSource;
 import me.deecaad.weaponmechanics.weapon.damage.WeaponDamageSource;
 import me.deecaad.weaponmechanics.weapon.explode.Explosion;
 import me.deecaad.weaponmechanics.weapon.explode.ExplosionTrigger;
+import me.deecaad.weaponmechanics.weapon.projectile.weaponprojectile.BlockPlacement;
 import me.deecaad.weaponmechanics.weapon.projectile.weaponprojectile.WeaponProjectile;
 import me.deecaad.weaponmechanics.weapon.weaponevents.ProjectileHitBlockEvent;
 import me.deecaad.weaponmechanics.weapon.weaponevents.ProjectileHitEntityEvent;
@@ -105,6 +106,11 @@ public class HitHandler {
         Bukkit.getPluginManager().callEvent(hitBlockEvent);
         if (hitBlockEvent.isCancelled())
             return true;
+
+        BlockPlacement blockPlacement = projectile.getBlockPlacement();
+        if (blockPlacement != null) {
+            blockPlacement.handleBlockPlacement(result, projectile);
+        }
 
         Explosion explosion = WeaponMechanics.getInstance().getWeaponConfigurations().getObject(projectile.getWeaponTitle() + ".Explosion", Explosion.class);
         if (explosion != null) {

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/explode/Explosion.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/explode/Explosion.java
@@ -296,7 +296,7 @@ public class Explosion implements Serializer<Explosion> {
 
         // Place/replace/remove blocks inside the explosion radius (e.g. fire bomb)
         if (blockPlacement != null) {
-            blockPlacement.handleExplosionPlacement(blocks);
+            blockPlacement.handleExplosionPlacement(origin, blocks);
         }
 
         if (projectile != null && projectile.getWeaponTitle() != null) {

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/explode/Explosion.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/explode/Explosion.java
@@ -24,6 +24,7 @@ import me.deecaad.weaponmechanics.weapon.explode.shapes.DefaultExplosion;
 import me.deecaad.weaponmechanics.weapon.explode.shapes.ExplosionShape;
 import me.deecaad.weaponmechanics.weapon.explode.shapes.ExplosionShapes;
 import me.deecaad.weaponmechanics.weapon.projectile.RemoveOnBlockCollisionProjectile;
+import me.deecaad.weaponmechanics.weapon.projectile.weaponprojectile.BlockPlacement;
 import me.deecaad.weaponmechanics.weapon.projectile.weaponprojectile.WeaponProjectile;
 import me.deecaad.weaponmechanics.weapon.stats.WeaponStat;
 import me.deecaad.weaponmechanics.weapon.weaponevents.ProjectileExplodeEvent;
@@ -64,6 +65,7 @@ public class Explosion implements Serializer<Explosion> {
     private AirStrike airStrike;
     private Flashbang flashbang;
     private MechanicManager mechanics;
+    private BlockPlacement blockPlacement;
 
     /**
      * Default constructor for serializer.
@@ -92,7 +94,8 @@ public class Explosion implements Serializer<Explosion> {
      */
     public Explosion(ExplosionShape shape, ExplosionExposure exposure, BlockDamage blockDamage,
         RegenerationData regeneration, Detonation detonation, double blockChance, double knockbackRate,
-        ClusterBomb clusterBomb, AirStrike airStrike, Flashbang flashbang, MechanicManager mechanics) {
+        ClusterBomb clusterBomb, AirStrike airStrike, Flashbang flashbang, MechanicManager mechanics,
+        BlockPlacement blockPlacement) {
 
         this.shape = shape;
         this.exposure = exposure;
@@ -105,6 +108,7 @@ public class Explosion implements Serializer<Explosion> {
         this.airStrike = airStrike;
         this.flashbang = flashbang;
         this.mechanics = mechanics;
+        this.blockPlacement = blockPlacement;
     }
 
     public ExplosionShape getShape() {
@@ -290,6 +294,11 @@ public class Explosion implements Serializer<Explosion> {
             damageBlocks(solid, false, origin, 0, playerWrapper, projectile);
         }
 
+        // Place/replace/remove blocks inside the explosion radius (e.g. fire bomb)
+        if (blockPlacement != null) {
+            blockPlacement.handleExplosionPlacement(blocks);
+        }
+
         if (projectile != null && projectile.getWeaponTitle() != null) {
             WeaponMechanics.getInstance().getWeaponHandler().getDamageHandler().tryUseExplosion(this, projectile, origin, entities);
 
@@ -473,8 +482,9 @@ public class Explosion implements Serializer<Explosion> {
         AirStrike airStrike = data.of("Airstrike").serialize(AirStrike.class).orElse(null);
         Flashbang flashbang = data.of("Flashbang").serialize(Flashbang.class).orElse(null);
         MechanicManager mechanics = data.of("Mechanics").serialize(MechanicManager.class).orElse(null);
+        BlockPlacement blockPlacement = data.of("Block_Placement").serialize(BlockPlacement.class).orElse(null);
 
         return new Explosion(shape, exposure, blockDamage, regeneration, detonation, blockChance,
-            knockbackRate, clusterBomb, airStrike, flashbang, mechanics);
+            knockbackRate, clusterBomb, airStrike, flashbang, mechanics, blockPlacement);
     }
 }

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/info/WeaponConverter.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/info/WeaponConverter.java
@@ -5,6 +5,7 @@ import me.deecaad.core.file.Serializer;
 import me.deecaad.core.file.SerializerException;
 import com.cjcrafter.foliascheduler.util.MinecraftVersions;
 import me.deecaad.weaponmechanics.WeaponMechanics;
+import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -21,6 +22,7 @@ public class WeaponConverter implements Serializer<WeaponConverter> {
     private boolean lore;
     private boolean enchantments;
     private boolean cmd;
+    private boolean itemModel;
 
     /**
      * Default constructor for serializer
@@ -28,12 +30,13 @@ public class WeaponConverter implements Serializer<WeaponConverter> {
     public WeaponConverter() {
     }
 
-    public WeaponConverter(boolean type, boolean name, boolean lore, boolean enchantments, boolean cmd) {
+    public WeaponConverter(boolean type, boolean name, boolean lore, boolean enchantments, boolean cmd, boolean itemModel) {
         this.type = type;
         this.name = name;
         this.lore = lore;
         this.enchantments = enchantments;
         this.cmd = cmd;
+        this.itemModel = itemModel;
     }
 
     /**
@@ -73,6 +76,13 @@ public class WeaponConverter implements Serializer<WeaponConverter> {
                 return false;
             }
             if (weaponMeta.hasCustomModelData() && weaponMeta.getCustomModelData() != otherMeta.getCustomModelData()) {
+                return false;
+            }
+        }
+        if (this.itemModel) {
+            NamespacedKey weaponItemModel = weaponMeta.hasItemModel() ? weaponMeta.getItemModel() : null;
+            NamespacedKey otherItemModel = otherMeta.hasItemModel() ? otherMeta.getItemModel() : null;
+            if (weaponItemModel == null ? otherItemModel != null : !weaponItemModel.equals(otherItemModel)) {
                 return false;
             }
         }
@@ -122,14 +132,15 @@ public class WeaponConverter implements Serializer<WeaponConverter> {
         boolean lore = data.of("Lore").getBool().orElse(false);
         boolean enchantments = data.of("Enchantments").getBool().orElse(false);
         boolean cmd = data.of("Custom_Model_Data").getBool().orElse(false);
+        boolean itemModel = data.of("Item_Model").getBool().orElse(false);
 
-        if (!type && !name && !lore && !enchantments && !cmd) {
-            throw data.exception(null, "'Type', 'Name', 'Lore', 'Enchantments', 'Custom_Model_Data' are all 'false'",
+        if (!type && !name && !lore && !enchantments && !cmd && !itemModel) {
+            throw data.exception(null, "'Type', 'Name', 'Lore', 'Enchantments', 'Custom_Model_Data', 'Item_Model' are all 'false'",
                 "One of them should be 'true' to allow weapon conversion",
                 "If you want to remove the weapon conversion feature, remove the '" + getKeyword() + "' option from config");
         }
 
         WeaponMechanics.getInstance().getWeaponHandler().getInfoHandler().addWeaponWithConvert(data.getKey().split("\\.")[0]);
-        return new WeaponConverter(type, name, lore, enchantments, cmd);
+        return new WeaponConverter(type, name, lore, enchantments, cmd, itemModel);
     }
 }

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/BlockPlacement.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/BlockPlacement.java
@@ -17,6 +17,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class BlockPlacement implements Serializer<BlockPlacement> {
 
@@ -32,6 +33,7 @@ public class BlockPlacement implements Serializer<BlockPlacement> {
     private int removeAfterTicks;
     private boolean lineOfSight;
     private double radius;
+    private double chance;
 
     /**
      * Default constructor for serializer
@@ -39,12 +41,13 @@ public class BlockPlacement implements Serializer<BlockPlacement> {
     public BlockPlacement() {
     }
 
-    public BlockPlacement(Material block, PlacementMode mode, int removeAfterTicks, boolean lineOfSight, double radius) {
+    public BlockPlacement(Material block, PlacementMode mode, int removeAfterTicks, boolean lineOfSight, double radius, double chance) {
         this.block = block;
         this.mode = mode;
         this.removeAfterTicks = removeAfterTicks;
         this.lineOfSight = lineOfSight;
         this.radius = radius;
+        this.chance = chance;
     }
 
     public void handleBlockPlacement(BlockTraceResult result, WeaponProjectile projectile) {
@@ -107,24 +110,16 @@ public class BlockPlacement implements Serializer<BlockPlacement> {
             }
 
             // Line-of-sight check: skip blocks that have a solid wall between them and the origin.
-            // Uses Bukkit's DDA raytracer so diagonal block corners are handled correctly.
+            // Uses Bukkit's DDA raytracer + 3 sample points within the candidate block to defeat
+            // hairline gaps where a single ray could slip through diagonally-placed blocks.
             if (lineOfSight && origin != null) {
-                Vector blockCenter = b.getLocation().add(0.5, 0.5, 0.5).toVector();
-                Vector dir = blockCenter.clone().subtract(origin.toVector());
-                double dist = dir.length();
-                if (dist > 0) {
-                    RayTraceResult hit = origin.getWorld().rayTraceBlocks(
-                        origin, dir.normalize(), dist, FluidCollisionMode.NEVER, true);
-                    if (hit != null) {
-                        // Something solid is in the way — allow only if the hit block IS the candidate
-                        // (relevant for REPLACE mode where the target itself is solid)
-                        Block hitBlock = hit.getHitBlock();
-                        if (hitBlock == null || hitBlock.getX() != b.getX()
-                            || hitBlock.getY() != b.getY() || hitBlock.getZ() != b.getZ())
-                            continue;
-                    }
-                }
+                if (isLineOfSightBlocked(origin, b))
+                    continue;
             }
+
+            // Roll the per-block placement chance (default 1.0 = always place)
+            if (chance < 1.0 && ThreadLocalRandom.current().nextDouble() >= chance)
+                continue;
 
             if (oldStates != null)
                 oldStates.add(b.getState());
@@ -138,6 +133,44 @@ public class BlockPlacement implements Serializer<BlockPlacement> {
                     state.update(true, true);
             }, (long) removeAfterTicks);
         }
+    }
+
+    /**
+     * Returns true if the origin does not have a clear line of sight to the candidate block.
+     * Casts 3 rays from {@code origin} to 3 different sample points spread inside the candidate
+     * block — defeats the rare case where a single ray slips through the corner where 4
+     * diagonally-placed blocks meet (a mathematically thin gap that DDA can ignore).
+     */
+    private boolean isLineOfSightBlocked(Location origin, Block candidate) {
+        Vector originVec = origin.toVector();
+        // Three sample points spread in 3D inside the block
+        double[][] samples = {
+            {0.5, 0.5, 0.5},
+            {0.25, 0.75, 0.25},
+            {0.75, 0.25, 0.75}
+        };
+
+        for (double[] s : samples) {
+            Vector target = candidate.getLocation().add(s[0], s[1], s[2]).toVector();
+            Vector dir = target.clone().subtract(originVec);
+            double dist = dir.length();
+            if (dist <= 0)
+                continue;
+
+            RayTraceResult hit = origin.getWorld().rayTraceBlocks(
+                origin, dir.normalize(), dist, FluidCollisionMode.NEVER, true);
+            if (hit == null)
+                continue; // this ray reached the candidate freely
+
+            // Something solid is in the way — only acceptable if it's the candidate itself
+            // (REPLACE mode where the target block is solid)
+            Block hitBlock = hit.getHitBlock();
+            if (hitBlock == null || hitBlock.getX() != candidate.getX()
+                || hitBlock.getY() != candidate.getY() || hitBlock.getZ() != candidate.getZ()) {
+                return true; // wall in the way for at least one of the rays → block is occluded
+            }
+        }
+        return false;
     }
 
     @Override
@@ -161,7 +194,12 @@ public class BlockPlacement implements Serializer<BlockPlacement> {
         int removeAfterTicks = data.of("Remove_After_Ticks").getInt().orElse(-1);
         boolean lineOfSight = data.of("Line_Of_Sight").getBool().orElse(false);
         double radius = data.of("Radius").getDouble().orElse(-1.0);
+        double chance = data.of("Chance").getDouble().orElse(1.0);
+        if (chance < 0.0 || chance > 1.0) {
+            throw data.exception("Chance", "'Chance' must be between 0.0 and 1.0 (got " + chance + ")",
+                "0.0 = never place, 1.0 = always place. Use a value like 0.5 for a 50% chance per block.");
+        }
 
-        return new BlockPlacement(block, mode, removeAfterTicks, lineOfSight, radius);
+        return new BlockPlacement(block, mode, removeAfterTicks, lineOfSight, radius, chance);
     }
 }

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/BlockPlacement.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/BlockPlacement.java
@@ -5,12 +5,12 @@ import me.deecaad.core.file.Serializer;
 import me.deecaad.core.file.SerializerException;
 import me.deecaad.core.utils.ray.BlockTraceResult;
 import me.deecaad.weaponmechanics.WeaponMechanics;
-import me.deecaad.weaponmechanics.weapon.explode.raytrace.Ray;
-import me.deecaad.weaponmechanics.weapon.explode.raytrace.TraceCollision;
+import org.bukkit.FluidCollisionMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
+import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -106,12 +106,24 @@ public class BlockPlacement implements Serializer<BlockPlacement> {
                     continue;
             }
 
-            // Line-of-sight check: skip blocks that have a solid wall between them and the origin
+            // Line-of-sight check: skip blocks that have a solid wall between them and the origin.
+            // Uses Bukkit's DDA raytracer so diagonal block corners are handled correctly.
             if (lineOfSight && origin != null) {
-                Vector dir = b.getLocation().add(0.5, 0.5, 0.5).toVector().subtract(origin.toVector());
-                Ray ray = new Ray(origin, dir);
-                if (!ray.trace(TraceCollision.BLOCK, 0.3).isEmpty())
-                    continue;
+                Vector blockCenter = b.getLocation().add(0.5, 0.5, 0.5).toVector();
+                Vector dir = blockCenter.clone().subtract(origin.toVector());
+                double dist = dir.length();
+                if (dist > 0) {
+                    RayTraceResult hit = origin.getWorld().rayTraceBlocks(
+                        origin, dir.normalize(), dist, FluidCollisionMode.NEVER, true);
+                    if (hit != null) {
+                        // Something solid is in the way — allow only if the hit block IS the candidate
+                        // (relevant for REPLACE mode where the target itself is solid)
+                        Block hitBlock = hit.getHitBlock();
+                        if (hitBlock == null || hitBlock.getX() != b.getX()
+                            || hitBlock.getY() != b.getY() || hitBlock.getZ() != b.getZ())
+                            continue;
+                    }
+                }
             }
 
             if (oldStates != null)

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/BlockPlacement.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/BlockPlacement.java
@@ -1,0 +1,83 @@
+package me.deecaad.weaponmechanics.weapon.projectile.weaponprojectile;
+
+import me.deecaad.core.file.SerializeData;
+import me.deecaad.core.file.Serializer;
+import me.deecaad.core.file.SerializerException;
+import me.deecaad.core.utils.ray.BlockTraceResult;
+import me.deecaad.weaponmechanics.WeaponMechanics;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.jetbrains.annotations.NotNull;
+
+public class BlockPlacement implements Serializer<BlockPlacement> {
+
+    public enum PlacementMode {
+        PLACE_ADJACENT,
+        REPLACE,
+        REMOVE
+    }
+
+    private Material block;
+    private PlacementMode mode;
+    private int removeAfterTicks;
+
+    /**
+     * Default constructor for serializer
+     */
+    public BlockPlacement() {
+    }
+
+    public BlockPlacement(Material block, PlacementMode mode, int removeAfterTicks) {
+        this.block = block;
+        this.mode = mode;
+        this.removeAfterTicks = removeAfterTicks;
+    }
+
+    public void handleBlockPlacement(BlockTraceResult result, WeaponProjectile projectile) {
+        Block target;
+        if (mode == PlacementMode.PLACE_ADJACENT) {
+            target = result.getBlock().getRelative(result.getHitFace());
+            // Only place in air, liquids, or passable blocks (grass, flowers, etc.)
+            Material targetType = target.getType();
+            if (!targetType.isAir() && !target.isLiquid() && !target.isPassable()) {
+                return;
+            }
+        } else {
+            target = result.getBlock();
+        }
+
+        BlockState oldState = target.getState();
+        Material placeMaterial = (mode == PlacementMode.REMOVE) ? Material.AIR : block;
+        target.setType(placeMaterial);
+
+        if (removeAfterTicks > 0) {
+            WeaponMechanics.getInstance().getFoliaScheduler().global().runDelayed(() -> {
+                oldState.update(true, true);
+            }, (long) removeAfterTicks);
+        }
+    }
+
+    @Override
+    public String getKeyword() {
+        return "Block_Placement";
+    }
+
+    @Override
+    public @NotNull BlockPlacement serialize(@NotNull SerializeData data) throws SerializerException {
+        PlacementMode mode = data.of("Mode").getEnum(PlacementMode.class).orElse(PlacementMode.PLACE_ADJACENT);
+
+        Material block = null;
+        if (mode != PlacementMode.REMOVE) {
+            block = data.of("Block").assertExists().getEnum(Material.class).get();
+            if (!block.isBlock()) {
+                throw data.exception("Block", "'" + block.name() + "' is not a placeable block material",
+                    "Use a solid block like STONE, SPONGE, DIRT, etc.");
+            }
+        }
+
+        int removeAfterTicks = data.of("Remove_After_Ticks").getInt().orElse(-1);
+
+        return new BlockPlacement(block, mode, removeAfterTicks);
+    }
+}

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/BlockPlacement.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/BlockPlacement.java
@@ -31,6 +31,7 @@ public class BlockPlacement implements Serializer<BlockPlacement> {
     private PlacementMode mode;
     private int removeAfterTicks;
     private boolean lineOfSight;
+    private double radius;
 
     /**
      * Default constructor for serializer
@@ -38,11 +39,12 @@ public class BlockPlacement implements Serializer<BlockPlacement> {
     public BlockPlacement() {
     }
 
-    public BlockPlacement(Material block, PlacementMode mode, int removeAfterTicks, boolean lineOfSight) {
+    public BlockPlacement(Material block, PlacementMode mode, int removeAfterTicks, boolean lineOfSight, double radius) {
         this.block = block;
         this.mode = mode;
         this.removeAfterTicks = removeAfterTicks;
         this.lineOfSight = lineOfSight;
+        this.radius = radius;
     }
 
     public void handleBlockPlacement(BlockTraceResult result, WeaponProjectile projectile) {
@@ -90,9 +92,19 @@ public class BlockPlacement implements Serializer<BlockPlacement> {
         Material placeMaterial = (mode == PlacementMode.REMOVE) ? Material.AIR : block;
         List<BlockState> oldStates = removeAfterTicks > 0 ? new ArrayList<>() : null;
 
+        double radiusSq = radius > 0 ? radius * radius : -1;
+        Vector originVec = origin != null ? origin.toVector() : null;
+
         for (Block b : blocks) {
             if (mode == PlacementMode.REPLACE_AIR && !b.getType().isAir() && !b.isPassable())
                 continue;
+
+            // Radius check: skip blocks outside the specified placement radius
+            if (radiusSq > 0 && originVec != null) {
+                Vector blockCenter = b.getLocation().add(0.5, 0.5, 0.5).toVector();
+                if (blockCenter.distanceSquared(originVec) > radiusSq)
+                    continue;
+            }
 
             // Line-of-sight check: skip blocks that have a solid wall between them and the origin
             if (lineOfSight && origin != null) {
@@ -136,7 +148,8 @@ public class BlockPlacement implements Serializer<BlockPlacement> {
 
         int removeAfterTicks = data.of("Remove_After_Ticks").getInt().orElse(-1);
         boolean lineOfSight = data.of("Line_Of_Sight").getBool().orElse(false);
+        double radius = data.of("Radius").getDouble().orElse(-1.0);
 
-        return new BlockPlacement(block, mode, removeAfterTicks, lineOfSight);
+        return new BlockPlacement(block, mode, removeAfterTicks, lineOfSight, radius);
     }
 }

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/BlockPlacement.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/BlockPlacement.java
@@ -5,10 +5,15 @@ import me.deecaad.core.file.Serializer;
 import me.deecaad.core.file.SerializerException;
 import me.deecaad.core.utils.ray.BlockTraceResult;
 import me.deecaad.weaponmechanics.WeaponMechanics;
+import me.deecaad.weaponmechanics.weapon.explode.raytrace.Ray;
+import me.deecaad.weaponmechanics.weapon.explode.raytrace.TraceCollision;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
+import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,6 +30,7 @@ public class BlockPlacement implements Serializer<BlockPlacement> {
     private Material block;
     private PlacementMode mode;
     private int removeAfterTicks;
+    private boolean lineOfSight;
 
     /**
      * Default constructor for serializer
@@ -32,10 +38,11 @@ public class BlockPlacement implements Serializer<BlockPlacement> {
     public BlockPlacement() {
     }
 
-    public BlockPlacement(Material block, PlacementMode mode, int removeAfterTicks) {
+    public BlockPlacement(Material block, PlacementMode mode, int removeAfterTicks, boolean lineOfSight) {
         this.block = block;
         this.mode = mode;
         this.removeAfterTicks = removeAfterTicks;
+        this.lineOfSight = lineOfSight;
     }
 
     public void handleBlockPlacement(BlockTraceResult result, WeaponProjectile projectile) {
@@ -73,9 +80,10 @@ public class BlockPlacement implements Serializer<BlockPlacement> {
      *   <li>{@link PlacementMode#PLACE_ADJACENT} — not applicable to explosions; call is ignored.</li>
      * </ul>
      *
+     * @param origin the explosion origin, used for line-of-sight checks when {@code lineOfSight} is enabled
      * @param blocks the list of blocks inside the explosion radius
      */
-    public void handleExplosionPlacement(List<Block> blocks) {
+    public void handleExplosionPlacement(@Nullable Location origin, List<Block> blocks) {
         if (mode == PlacementMode.PLACE_ADJACENT)
             return;
 
@@ -85,6 +93,14 @@ public class BlockPlacement implements Serializer<BlockPlacement> {
         for (Block b : blocks) {
             if (mode == PlacementMode.REPLACE_AIR && !b.getType().isAir() && !b.isPassable())
                 continue;
+
+            // Line-of-sight check: skip blocks that have a solid wall between them and the origin
+            if (lineOfSight && origin != null) {
+                Vector dir = b.getLocation().add(0.5, 0.5, 0.5).toVector().subtract(origin.toVector());
+                Ray ray = new Ray(origin, dir);
+                if (!ray.trace(TraceCollision.BLOCK, 0.3).isEmpty())
+                    continue;
+            }
 
             if (oldStates != null)
                 oldStates.add(b.getState());
@@ -119,7 +135,8 @@ public class BlockPlacement implements Serializer<BlockPlacement> {
         }
 
         int removeAfterTicks = data.of("Remove_After_Ticks").getInt().orElse(-1);
+        boolean lineOfSight = data.of("Line_Of_Sight").getBool().orElse(false);
 
-        return new BlockPlacement(block, mode, removeAfterTicks);
+        return new BlockPlacement(block, mode, removeAfterTicks, lineOfSight);
     }
 }

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/BlockPlacement.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/BlockPlacement.java
@@ -10,11 +10,15 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class BlockPlacement implements Serializer<BlockPlacement> {
 
     public enum PlacementMode {
         PLACE_ADJACENT,
         REPLACE,
+        REPLACE_AIR,
         REMOVE
     }
 
@@ -54,6 +58,44 @@ public class BlockPlacement implements Serializer<BlockPlacement> {
         if (removeAfterTicks > 0) {
             WeaponMechanics.getInstance().getFoliaScheduler().global().runDelayed(() -> {
                 oldState.update(true, true);
+            }, (long) removeAfterTicks);
+        }
+    }
+
+    /**
+     * Handles block placement for an explosion. Iterates all blocks in the explosion radius
+     * and places/replaces/removes blocks according to the configured mode.
+     *
+     * <ul>
+     *   <li>{@link PlacementMode#REPLACE} — replaces every block in the radius with the configured material.</li>
+     *   <li>{@link PlacementMode#REPLACE_AIR} — replaces only air/passable blocks (e.g. place fire in open space).</li>
+     *   <li>{@link PlacementMode#REMOVE} — sets every block in the radius to AIR.</li>
+     *   <li>{@link PlacementMode#PLACE_ADJACENT} — not applicable to explosions; call is ignored.</li>
+     * </ul>
+     *
+     * @param blocks the list of blocks inside the explosion radius
+     */
+    public void handleExplosionPlacement(List<Block> blocks) {
+        if (mode == PlacementMode.PLACE_ADJACENT)
+            return;
+
+        Material placeMaterial = (mode == PlacementMode.REMOVE) ? Material.AIR : block;
+        List<BlockState> oldStates = removeAfterTicks > 0 ? new ArrayList<>() : null;
+
+        for (Block b : blocks) {
+            if (mode == PlacementMode.REPLACE_AIR && !b.getType().isAir() && !b.isPassable())
+                continue;
+
+            if (oldStates != null)
+                oldStates.add(b.getState());
+
+            b.setType(placeMaterial);
+        }
+
+        if (oldStates != null && !oldStates.isEmpty()) {
+            WeaponMechanics.getInstance().getFoliaScheduler().global().runDelayed(() -> {
+                for (BlockState state : oldStates)
+                    state.update(true, true);
             }, (long) removeAfterTicks);
         }
     }

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/Projectile.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/Projectile.java
@@ -31,6 +31,7 @@ public class Projectile implements Serializer<Projectile> {
     private Sticky sticky;
     private Through through;
     private Bouncy bouncy;
+    private BlockPlacement blockPlacement;
     private MechanicManager mechanics;
 
     /**
@@ -39,11 +40,12 @@ public class Projectile implements Serializer<Projectile> {
     public Projectile() {
     }
 
-    public Projectile(ProjectileSettings projectileSettings, Sticky sticky, Through through, Bouncy bouncy, MechanicManager mechanics) {
+    public Projectile(ProjectileSettings projectileSettings, Sticky sticky, Through through, Bouncy bouncy, BlockPlacement blockPlacement, MechanicManager mechanics) {
         this.projectileSettings = projectileSettings;
         this.sticky = sticky;
         this.through = through;
         this.bouncy = bouncy;
+        this.blockPlacement = blockPlacement;
         this.mechanics = mechanics;
     }
 
@@ -119,7 +121,7 @@ public class Projectile implements Serializer<Projectile> {
      * @param weaponTitle the weapon title used to shoot
      */
     public WeaponProjectile create(LivingEntity shooter, Location location, Vector motion, ItemStack weaponStack, String weaponTitle, EquipmentSlot hand) {
-        return new WeaponProjectile(projectileSettings, shooter, location, motion, weaponStack, weaponTitle, hand, sticky, through, bouncy);
+        return new WeaponProjectile(projectileSettings, shooter, location, motion, weaponStack, weaponTitle, hand, sticky, through, bouncy, blockPlacement);
     }
 
     @Override
@@ -157,7 +159,8 @@ public class Projectile implements Serializer<Projectile> {
         Sticky sticky = data.of("Sticky").serialize(Sticky.class).orElse(null);
         Through through = data.of("Through").serialize(Through.class).orElse(null);
         Bouncy bouncy = data.of("Bouncy").serialize(Bouncy.class).orElse(null);
+        BlockPlacement blockPlacement = data.of("Block_Placement").serialize(BlockPlacement.class).orElse(null);
         MechanicManager mechanics = data.of("Mechanics").serialize(MechanicManager.class).orElse(null);
-        return new Projectile(projectileSettings, sticky, through, bouncy, mechanics);
+        return new Projectile(projectileSettings, sticky, through, bouncy, blockPlacement, mechanics);
     }
 }

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/WeaponProjectile.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/WeaponProjectile.java
@@ -32,6 +32,7 @@ public class WeaponProjectile extends AProjectile {
     private boolean isThroughChanged;
     private Bouncy bouncy;
     private boolean isBouncyChanged;
+    private BlockPlacement blockPlacement;
 
     private final ItemStack weaponStack;
     private final String weaponTitle;
@@ -53,13 +54,14 @@ public class WeaponProjectile extends AProjectile {
 
     public WeaponProjectile(ProjectileSettings projectileSettings, LivingEntity shooter, Location location,
         Vector motion, ItemStack weaponStack, String weaponTitle, EquipmentSlot hand,
-        Sticky sticky, Through through, Bouncy bouncy) {
+        Sticky sticky, Through through, Bouncy bouncy, BlockPlacement blockPlacement) {
         super(shooter, location, motion);
 
         this.projectileSettings = projectileSettings;
         this.sticky = sticky;
         this.through = through;
         this.bouncy = bouncy;
+        this.blockPlacement = blockPlacement;
 
         this.weaponStack = weaponStack;
         this.weaponTitle = weaponTitle;
@@ -90,7 +92,7 @@ public class WeaponProjectile extends AProjectile {
      * @return the cloned projectile
      */
     public WeaponProjectile clone(Location location, Vector motion) {
-        return new WeaponProjectile(projectileSettings, getShooter(), location, motion, weaponStack, weaponTitle, hand, sticky, through, bouncy);
+        return new WeaponProjectile(projectileSettings, getShooter(), location, motion, weaponStack, weaponTitle, hand, sticky, through, bouncy, blockPlacement);
     }
 
     public ProjectileSettings getProjectileSettings() {
@@ -183,6 +185,10 @@ public class WeaponProjectile extends AProjectile {
     public void setBouncy(@Nullable Bouncy bouncy, boolean isBouncyChanged) {
         this.bouncy = bouncy;
         this.isBouncyChanged = isBouncyChanged;
+    }
+
+    public @Nullable BlockPlacement getBlockPlacement() {
+        return blockPlacement;
     }
 
     @Override

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/reload/ReloadHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/reload/ReloadHandler.java
@@ -108,6 +108,14 @@ public class ReloadHandler implements IValidator, TriggerListener {
                 if (ammo.getOutOfAmmoMechanics() != null) {
                     ammo.getOutOfAmmoMechanics().use(new CastData(shooter, weaponTitle, weaponStack));
                 }
+                // Send a configurable "no ammo" message to the player
+                Player player = playerWrapper.getPlayer();
+                String noAmmoMessage = WeaponMechanics.getInstance().getConfiguration().getString("Messages.Reload.No_Ammo", "");
+                if (!noAmmoMessage.isEmpty()) {
+                    PlaceholderMessage message = new PlaceholderMessage(StringUtil.colorAdventure(noAmmoMessage));
+                    Component component = message.replaceAndDeserialize(PlaceholderData.of(player, weaponStack, weaponTitle, slot));
+                    player.sendMessage(component);
+                }
                 return false;
             }
         }

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/reload/ReloadHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/reload/ReloadHandler.java
@@ -108,13 +108,13 @@ public class ReloadHandler implements IValidator, TriggerListener {
                 if (ammo.getOutOfAmmoMechanics() != null) {
                     ammo.getOutOfAmmoMechanics().use(new CastData(shooter, weaponTitle, weaponStack));
                 }
-                // Send a configurable "no ammo" message to the player
+                // Send a configurable "no ammo" message to the player as an action bar
                 Player player = playerWrapper.getPlayer();
                 String noAmmoMessage = WeaponMechanics.getInstance().getConfiguration().getString("Messages.Reload.No_Ammo", "");
                 if (!noAmmoMessage.isEmpty()) {
                     PlaceholderMessage message = new PlaceholderMessage(StringUtil.colorAdventure(noAmmoMessage));
                     Component component = message.replaceAndDeserialize(PlaceholderData.of(player, weaponStack, weaponTitle, slot));
-                    player.sendMessage(component);
+                    player.sendActionBar(component);
                 }
                 return false;
             }

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/reload/ReloadHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/reload/ReloadHandler.java
@@ -88,19 +88,36 @@ public class ReloadHandler implements IValidator, TriggerListener {
         EquipmentSlot slot, boolean dualWield, boolean isReloadLoop) {
 
         // Don't try to reload if either one of the hands is already reloading / full autoing
-        HandData mainHandData = entityWrapper.getMainHandData();
         HandData offHandData = entityWrapper.getOffHandData();
+        LivingEntity shooter = entityWrapper.getEntity();
+        HandData mainHandData = entityWrapper.getMainHandData();
         if (mainHandData.isReloading() || mainHandData.isUsingFullAuto() || mainHandData.isUsingBurst()
             || offHandData.isReloading() || offHandData.isUsingFullAuto() || offHandData.isUsingBurst()) {
             return false;
         }
 
+        Configuration config = WeaponMechanics.getInstance().getWeaponConfigurations();
+        PlayerWrapper playerWrapper = shooter.getType() != EntityType.PLAYER ? null : (PlayerWrapper) entityWrapper;
+        WeaponInfoDisplay weaponInfoDisplay = playerWrapper == null ? null : WeaponMechanics.getInstance().getWeaponConfigurations().getObject(weaponTitle + ".Info.Weapon_Info_Display", WeaponInfoDisplay.class);
+
+        // Check if the player has ammo BEFORE starting the reload animation
+        AmmoConfig ammo = playerWrapper != null ? config.getObject(weaponTitle + ".Reload.Ammo", AmmoConfig.class) : null;
+        if (ammo != null && !ammo.hasAmmo(weaponTitle, weaponStack, playerWrapper)) {
+            // Creative mode bypass... #176
+            if (playerWrapper.getPlayer().getGameMode() != GameMode.CREATIVE || !WeaponMechanics.getInstance().getConfiguration().getBoolean("Creative_Mode_Bypass_Ammo")) {
+                if (ammo.getOutOfAmmoMechanics() != null) {
+                    ammo.getOutOfAmmoMechanics().use(new CastData(shooter, weaponTitle, weaponStack));
+                }
+                return false;
+            }
+        }
+
         WeaponPreReloadEvent preReloadEvent = new WeaponPreReloadEvent(weaponTitle, weaponStack, entityWrapper.getEntity(), slot);
         Bukkit.getPluginManager().callEvent(preReloadEvent);
-        if (preReloadEvent.isCancelled())
+        if (preReloadEvent.isCancelled()) {
             return false;
+        }
 
-        Configuration config = WeaponMechanics.getInstance().getWeaponConfigurations();
 
         int reloadDuration = config.getInt(weaponTitle + ".Reload.Reload_Duration");
         int tempMagazineSize = config.getInt(weaponTitle + ".Reload.Magazine_Size");
@@ -109,7 +126,6 @@ public class ReloadHandler implements IValidator, TriggerListener {
             return false;
         }
 
-        LivingEntity shooter = entityWrapper.getEntity();
 
         // Handle permissions
         boolean hasPermission = weaponHandler.getInfoHandler().hasPermission(entityWrapper.getEntity(), weaponTitle);
@@ -139,8 +155,6 @@ public class ReloadHandler implements IValidator, TriggerListener {
 
         int ammoPerReload = config.getInt(weaponTitle + ".Reload.Ammo_Per_Reload", -1);
 
-        PlayerWrapper playerWrapper = shooter.getType() != EntityType.PLAYER ? null : (PlayerWrapper) entityWrapper;
-        WeaponInfoDisplay weaponInfoDisplay = playerWrapper == null ? null : WeaponMechanics.getInstance().getWeaponConfigurations().getObject(weaponTitle + ".Info.Weapon_Info_Display", WeaponInfoDisplay.class);
 
         FirearmAction firearmAction = config.getObject(weaponTitle + ".Firearm_Action", FirearmAction.class);
         FirearmState state = null;
@@ -211,16 +225,6 @@ public class ReloadHandler implements IValidator, TriggerListener {
             }
 
             return false;
-        }
-
-        AmmoConfig ammo = playerWrapper != null ? config.getObject(weaponTitle + ".Reload.Ammo", AmmoConfig.class) : null;
-        if (ammo != null && !ammo.hasAmmo(weaponTitle, weaponStack, playerWrapper)) {
-            // Creative mode bypass... #176
-            if (playerWrapper.getPlayer().getGameMode() != GameMode.CREATIVE || !WeaponMechanics.getInstance().getConfiguration().getBoolean("Creative_Mode_Bypass_Ammo")) {
-                if (ammo.getOutOfAmmoMechanics() != null)
-                    ammo.getOutOfAmmoMechanics().use(new CastData(shooter, weaponTitle, weaponStack));
-                return false;
-            }
         }
 
         // Check how much ammo should be added during this reload iteration
@@ -513,7 +517,7 @@ public class ReloadHandler implements IValidator, TriggerListener {
      * @return false if can't consume ammo (no enough ammo left)
      */
     public boolean consumeAmmo(ItemStack weaponStack, String weaponTitle, int amount) {
-        int ammoLeft = getAmmoLeft(weaponStack, weaponTitle);
+        int ammoLeft = getAmmoLeft(weaponStack, weaponTitle); // 0
 
         // -1 means infinite ammo
         if (ammoLeft != -1) {

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/reload/ammo/AmmoConverter.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/reload/ammo/AmmoConverter.java
@@ -15,7 +15,7 @@ public class AmmoConverter extends WeaponConverter {
     }
 
     public AmmoConverter(boolean type, boolean name, boolean lore, boolean enchantments, boolean cmd) {
-        super(type, name, lore, enchantments, cmd);
+        super(type, name, lore, enchantments, cmd, false);
     }
 
     @Override

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/scope/ScopeHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/scope/ScopeHandler.java
@@ -249,6 +249,10 @@ public class ScopeHandler implements IValidator, TriggerListener {
             TaskImplementation<Void> task = WeaponCompatibilityAPI.getWeaponCompatibility()
                 .playAdsSettleAnimation(player, adsSpeedTicks);
             zoomData.setAdsSettleTask(task);
+
+            if (config.getBoolean(weaponTitle + ".Scope.ADS_Show_Cooldown_Icon")) {
+                player.setCooldown(weaponStack.getType(), adsSpeedTicks);
+            }
         }
 
         return true;
@@ -265,6 +269,11 @@ public class ScopeHandler implements IValidator, TriggerListener {
 
         // Stop any active ADS settling when zooming out
         zoomData.stopSettling();
+
+        if (entity instanceof Player player
+            && WeaponMechanics.getInstance().getWeaponConfigurations().getBoolean(weaponTitle + ".Scope.ADS_Show_Cooldown_Icon")) {
+            player.setCooldown(weaponStack.getType(), 0);
+        }
 
         MechanicManager zoomOffMechanics = WeaponMechanics.getInstance().getWeaponConfigurations().getObject(weaponTitle + ".Scope.Zoom_Off.Mechanics", MechanicManager.class);
 

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/scope/ScopeHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/scope/ScopeHandler.java
@@ -1,5 +1,6 @@
 package me.deecaad.weaponmechanics.weapon.scope;
 
+import com.cjcrafter.foliascheduler.TaskImplementation;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.protocol.potion.PotionTypes;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityEffect;
@@ -13,6 +14,7 @@ import me.deecaad.core.placeholder.PlaceholderData;
 import me.deecaad.core.placeholder.PlaceholderMessage;
 import me.deecaad.core.utils.NumberUtil;
 import me.deecaad.weaponmechanics.WeaponMechanics;
+import me.deecaad.weaponmechanics.compatibility.WeaponCompatibilityAPI;
 import me.deecaad.weaponmechanics.weapon.WeaponHandler;
 import me.deecaad.weaponmechanics.weapon.trigger.Trigger;
 import me.deecaad.weaponmechanics.weapon.trigger.TriggerListener;
@@ -193,6 +195,17 @@ public class ScopeHandler implements IValidator, TriggerListener {
                 if (weaponScopeEvent.getMechanics() != null)
                     weaponScopeEvent.getMechanics().use(new CastData(entity, weaponTitle, weaponStack));
 
+                // Restart ADS settling on each zoom stack (player is re-adjusting their aim)
+                int adsSpeedMillis = config.getInt(weaponTitle + ".Scope.ADS_Speed");
+                if (adsSpeedMillis > 0 && entity instanceof Player player) {
+                    int adsSpeedTicks = adsSpeedMillis / 50;
+                    zoomData.stopSettling(); // cancel previous settling first
+                    zoomData.startSettling(adsSpeedMillis);
+                    TaskImplementation<Void> task = WeaponCompatibilityAPI.getWeaponCompatibility()
+                        .playAdsSettleAnimation(player, adsSpeedTicks);
+                    zoomData.setAdsSettleTask(task);
+                }
+
                 return true;
             } else {
                 WeaponMechanics.getInstance().getDebugger().warning("For some reason zoom in was called on entity when it shouldn't have.",
@@ -228,6 +241,16 @@ public class ScopeHandler implements IValidator, TriggerListener {
         HandData handData = slot == EquipmentSlot.HAND ? entityWrapper.getMainHandData() : entityWrapper.getOffHandData();
         handData.setLastScopeTime(System.currentTimeMillis());
 
+        // ADS settling: temporarily keep hipfire accuracy until the timer expires
+        int adsSpeedMillis = config.getInt(weaponTitle + ".Scope.ADS_Speed");
+        if (adsSpeedMillis > 0 && entity instanceof Player player) {
+            int adsSpeedTicks = adsSpeedMillis / 50;
+            zoomData.startSettling(adsSpeedMillis);
+            TaskImplementation<Void> task = WeaponCompatibilityAPI.getWeaponCompatibility()
+                .playAdsSettleAnimation(player, adsSpeedTicks);
+            zoomData.setAdsSettleTask(task);
+        }
+
         return true;
     }
 
@@ -239,6 +262,9 @@ public class ScopeHandler implements IValidator, TriggerListener {
         if (!zoomData.isZooming())
             return false;
         LivingEntity entity = entityWrapper.getEntity();
+
+        // Stop any active ADS settling when zooming out
+        zoomData.stopSettling();
 
         MechanicManager zoomOffMechanics = WeaponMechanics.getInstance().getWeaponConfigurations().getObject(weaponTitle + ".Scope.Zoom_Off.Mechanics", MechanicManager.class);
 
@@ -371,6 +397,12 @@ public class ScopeHandler implements IValidator, TriggerListener {
         if (shootDelayAfterScope != 0) {
             // Convert to millis
             configuration.set(data.getKey() + ".Shoot_Delay_After_Scope", shootDelayAfterScope * 50);
+        }
+
+        int adsSpeed = data.of("ADS_Speed").getInt().orElse(0);
+        if (adsSpeed != 0) {
+            // Convert to millis (same pattern as Shoot_Delay_After_Scope)
+            configuration.set(data.getKey() + ".ADS_Speed", adsSpeed * 50);
         }
     }
 }

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/shoot/AModifyWhen.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/shoot/AModifyWhen.java
@@ -3,6 +3,7 @@ package me.deecaad.weaponmechanics.weapon.shoot;
 import me.deecaad.core.file.Serializer;
 import me.deecaad.weaponmechanics.wrappers.EntityWrapper;
 import me.deecaad.weaponmechanics.wrappers.PlayerWrapper;
+import me.deecaad.weaponmechanics.wrappers.ZoomData;
 
 public abstract class AModifyWhen implements Serializer<AModifyWhen> {
 
@@ -53,8 +54,13 @@ public abstract class AModifyWhen implements Serializer<AModifyWhen> {
         if (always != null) {
             tempNumber = always.applyTo(tempNumber);
         }
-        if (zooming != null && (entityWrapper.getMainHandData().getZoomData().isZooming() || entityWrapper.getOffHandData().getZoomData().isZooming())) {
-            tempNumber = zooming.applyTo(tempNumber);
+        if (zooming != null) {
+            ZoomData mainZoom = entityWrapper.getMainHandData().getZoomData();
+            ZoomData offZoom = entityWrapper.getOffHandData().getZoomData();
+            // Skip the Zooming modifier while ADS is still settling (player has hipfire accuracy)
+            if ((mainZoom.isZooming() || offZoom.isZooming()) && !mainZoom.isSettling() && !offZoom.isSettling()) {
+                tempNumber = zooming.applyTo(tempNumber);
+            }
         }
         if (sneaking != null && entityWrapper.isSneaking()) {
             tempNumber = sneaking.applyTo(tempNumber);

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/wrappers/ZoomData.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/wrappers/ZoomData.java
@@ -1,11 +1,16 @@
 package me.deecaad.weaponmechanics.wrappers;
 
+import com.cjcrafter.foliascheduler.TaskImplementation;
 import me.deecaad.core.mechanics.CastData;
 import me.deecaad.core.mechanics.MechanicManager;
 import me.deecaad.weaponmechanics.WeaponMechanics;
 import me.deecaad.weaponmechanics.weapon.scope.ScopeHandler;
 import me.deecaad.weaponmechanics.weapon.weaponevents.WeaponScopeEvent;
 import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
@@ -15,12 +20,23 @@ import org.vivecraft.api.data.VRPose;
 
 public class ZoomData {
 
+    /**
+     * The NamespacedKey used for the temporary attack speed attribute modifier applied during ADS settling.
+     * Stored here so both ZoomData and the compatibility layer share the same key.
+     */
+    public static final NamespacedKey ADS_SPEED_MODIFIER_KEY = new NamespacedKey("weaponmechanics", "ads_speed");
+
     private final HandData handData;
     private double zoomAmount;
     private int zoomStacks;
     private boolean zoomNightVision;
     private ItemStack scopeWeaponStack;
     private String scopeWeaponTitle;
+
+    /** System.currentTimeMillis() timestamp when ADS settling ends. 0 = not settling. */
+    private long scopeSettleEndTime = 0;
+    /** Scheduled task that removes the ADS speed attribute modifier when settling completes. */
+    private TaskImplementation<Void> adsSettleTask;
 
     public ZoomData(HandData handData) {
         this.handData = handData;
@@ -100,7 +116,60 @@ public class ZoomData {
         this.zoomNightVision = zoomNightVision;
     }
 
+    /**
+     * @return {@code true} if the ADS settling timer is currently active (scope was just entered and
+     *     accuracy has not yet transitioned to full ADS accuracy).
+     */
+    public boolean isSettling() {
+        return scopeSettleEndTime != 0 && System.currentTimeMillis() < scopeSettleEndTime;
+    }
+
+    /**
+     * Starts the ADS settling timer. Call this when a player enters scope.
+     *
+     * @param durationMillis how long (in milliseconds) until full ADS accuracy is reached
+     */
+    public void startSettling(long durationMillis) {
+        this.scopeSettleEndTime = System.currentTimeMillis() + durationMillis;
+    }
+
+    /**
+     * Stores the task scheduled to remove the ADS speed modifier at the end of settling.
+     * Call {@link #stopSettling()} to cancel it early.
+     */
+    public void setAdsSettleTask(TaskImplementation<Void> task) {
+        this.adsSettleTask = task;
+    }
+
+    /**
+     * Stops ADS settling immediately: cancels the pending restore task and removes the temporary
+     * attack speed modifier from the player. Safe to call when already not settling.
+     */
+    public void stopSettling() {
+        this.scopeSettleEndTime = 0;
+        if (adsSettleTask != null) {
+            adsSettleTask.cancel();
+            adsSettleTask = null;
+        }
+        // Remove the temporary attack speed modifier if it is still on the player
+        EntityWrapper entityWrapper = handData.getEntityWrapper();
+        if (entityWrapper.getEntity() instanceof Player player) {
+            AttributeInstance attr = player.getAttribute(Attribute.ATTACK_SPEED);
+            if (attr != null) {
+                for (AttributeModifier mod : new java.util.ArrayList<>(attr.getModifiers())) {
+                    if (ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                        attr.removeModifier(mod);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
     public void ifZoomingForceZoomOut() {
+        // Stop any active ADS settling (cancels task + removes attribute modifier)
+        stopSettling();
+
         if (isZooming()) {
 
             // IF player is in VR this happens

--- a/weaponmechanics-core/src/main/kotlin/me/deecaad/weaponmechanics/WeaponMechanicsCommand.kt
+++ b/weaponmechanics-core/src/main/kotlin/me/deecaad/weaponmechanics/WeaponMechanicsCommand.kt
@@ -1002,7 +1002,7 @@ object WeaponMechanicsCommand {
                 val explosion =
                     Explosion(
                         shape, exposure, blockDamage, regeneration, null, 0.0, 1.0,
-                        null, null, Flashbang(10.0, null), null,
+                        null, null, Flashbang(10.0, null), null, null,
                     )
                 explosion.explode(cause, origin, null)
             },

--- a/weaponmechanics-core/src/main/kotlin/me/deecaad/weaponmechanics/WeaponMechanicsCommand.kt
+++ b/weaponmechanics-core/src/main/kotlin/me/deecaad/weaponmechanics/WeaponMechanicsCommand.kt
@@ -1395,7 +1395,7 @@ object WeaponMechanicsCommand {
                 gravity, false, -1.0, false,
                 -1.0, 0.99, 0.96, 0.98, false, 600, -1.0, 0.1,
             )
-        val projectile = Projectile(projectileSettings, null, null, null, null)
+        val projectile = Projectile(projectileSettings, null, null, null, null, null)
         projectile.shoot(sender, sender.eyeLocation, sender.location.direction.multiply(speed), null, null, null)
     }
 

--- a/weaponmechanics-core/src/main/resources/WeaponMechanics/config.yml
+++ b/weaponmechanics-core/src/main/resources/WeaponMechanics/config.yml
@@ -40,6 +40,9 @@ Assists_Event:
 Messages:
   Permissions:
     Use_Weapon: "&4You do not have permission to use %weapon-title%"
+  Reload:
+    # Set to empty string ("") to disable this message
+    No_Ammo: "<red>You don't have enough ammo to reload <gold>%weapon-title%<red>!"
 
 # Automatically download MechanicsCore when not already installed.
 Mechanics_Core_Download:

--- a/weaponmechanics-platforms/paper/v1_21_R2/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R2.java
+++ b/weaponmechanics-platforms/paper/v1_21_R2/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R2.java
@@ -83,14 +83,19 @@ public class v1_21_R2 implements IWeaponCompatibility {
     @Override
     public TaskImplementation<Void> playAdsSettleAnimation(Player player, int durationTicks) {
         // Reset the attack strength ticker to trigger the item-drop animation client-side
-        ((CraftPlayer) player).getHandle().attackStrengthTicker = 0;
+        try {
+            java.lang.reflect.Field ticker = net.minecraft.world.entity.LivingEntity.class.getDeclaredField("attackStrengthTicker");
+            ticker.setAccessible(true);
+            ticker.set(((CraftPlayer) player).getHandle(), 0);
+        } catch (Exception ignored) {
+        }
 
         // Temporarily set attack speed so the animation finishes in exactly durationTicks ticks.
         // Formula: fullRaiseTicks = 1.0 / attackSpeed * 20  =>  attackSpeed = 20.0 / durationTicks
         AttributeInstance attr = player.getAttribute(Attribute.ATTACK_SPEED);
         if (attr != null) {
             double requiredSpeed = 20.0 / Math.max(1, durationTicks);
-            double addValue = requiredSpeed - attr.getBaseValue();
+            double addValue = requiredSpeed - attr.getValue();
             // Remove any leftover modifier from a previous scope cycle first
             for (AttributeModifier mod : new ArrayList<>(attr.getModifiers())) {
                 if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {

--- a/weaponmechanics-platforms/paper/v1_21_R2/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R2.java
+++ b/weaponmechanics-platforms/paper/v1_21_R2/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R2.java
@@ -1,5 +1,8 @@
 package me.deecaad.weaponmechanics.compatibility;
 
+import com.cjcrafter.foliascheduler.TaskImplementation;
+import me.deecaad.weaponmechanics.WeaponMechanics;
+import me.deecaad.weaponmechanics.wrappers.ZoomData;
 import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageSources;
@@ -7,10 +10,14 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.PositionMoveRotation;
 import net.minecraft.world.entity.Relative;
 import net.minecraft.world.phys.Vec3;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.craftbukkit.entity.CraftLivingEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -71,5 +78,40 @@ public class v1_21_R2 implements IWeaponCompatibility {
     @Override
     public void setKiller(org.bukkit.entity.LivingEntity victim, Player killer) {
         ((CraftLivingEntity) victim).getHandle().lastHurtByMob = ((CraftPlayer) killer).getHandle();
+    }
+
+    @Override
+    public TaskImplementation<Void> playAdsSettleAnimation(Player player, int durationTicks) {
+        // Reset the attack strength ticker to trigger the item-drop animation client-side
+        ((CraftPlayer) player).getHandle().attackStrengthTicker = 0;
+
+        // Temporarily set attack speed so the animation finishes in exactly durationTicks ticks.
+        // Formula: fullRaiseTicks = 1.0 / attackSpeed * 20  =>  attackSpeed = 20.0 / durationTicks
+        AttributeInstance attr = player.getAttribute(Attribute.ATTACK_SPEED);
+        if (attr != null) {
+            double requiredSpeed = 20.0 / Math.max(1, durationTicks);
+            double addValue = requiredSpeed - attr.getBaseValue();
+            // Remove any leftover modifier from a previous scope cycle first
+            for (AttributeModifier mod : new ArrayList<>(attr.getModifiers())) {
+                if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                    attr.removeModifier(mod);
+                    break;
+                }
+            }
+            attr.addModifier(new AttributeModifier(ZoomData.ADS_SPEED_MODIFIER_KEY, addValue, AttributeModifier.Operation.ADD_NUMBER));
+        }
+
+        // Schedule removal of the modifier once the animation is done
+        return WeaponMechanics.getInstance().getFoliaScheduler().entity(player).runDelayed(() -> {
+            AttributeInstance a = player.getAttribute(Attribute.ATTACK_SPEED);
+            if (a != null) {
+                for (AttributeModifier mod : new ArrayList<>(a.getModifiers())) {
+                    if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                        a.removeModifier(mod);
+                        break;
+                    }
+                }
+            }
+        }, (long) durationTicks);
     }
 }

--- a/weaponmechanics-platforms/paper/v1_21_R3/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R3.java
+++ b/weaponmechanics-platforms/paper/v1_21_R3/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R3.java
@@ -1,5 +1,8 @@
 package me.deecaad.weaponmechanics.compatibility;
 
+import com.cjcrafter.foliascheduler.TaskImplementation;
+import me.deecaad.weaponmechanics.WeaponMechanics;
+import me.deecaad.weaponmechanics.wrappers.ZoomData;
 import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageSources;
@@ -7,10 +10,14 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.PositionMoveRotation;
 import net.minecraft.world.entity.Relative;
 import net.minecraft.world.phys.Vec3;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.craftbukkit.entity.CraftLivingEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -71,5 +78,35 @@ public class v1_21_R3 implements IWeaponCompatibility {
     @Override
     public void setKiller(org.bukkit.entity.LivingEntity victim, Player killer) {
         ((CraftLivingEntity) victim).getHandle().lastHurtByMob = ((CraftPlayer) killer).getHandle();
+    }
+
+    @Override
+    public TaskImplementation<Void> playAdsSettleAnimation(Player player, int durationTicks) {
+        ((CraftPlayer) player).getHandle().attackStrengthTicker = 0;
+
+        AttributeInstance attr = player.getAttribute(Attribute.ATTACK_SPEED);
+        if (attr != null) {
+            double requiredSpeed = 20.0 / Math.max(1, durationTicks);
+            double addValue = requiredSpeed - attr.getBaseValue();
+            for (AttributeModifier mod : new ArrayList<>(attr.getModifiers())) {
+                if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                    attr.removeModifier(mod);
+                    break;
+                }
+            }
+            attr.addModifier(new AttributeModifier(ZoomData.ADS_SPEED_MODIFIER_KEY, addValue, AttributeModifier.Operation.ADD_NUMBER));
+        }
+
+        return WeaponMechanics.getInstance().getFoliaScheduler().entity(player).runDelayed(() -> {
+            AttributeInstance a = player.getAttribute(Attribute.ATTACK_SPEED);
+            if (a != null) {
+                for (AttributeModifier mod : new ArrayList<>(a.getModifiers())) {
+                    if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                        a.removeModifier(mod);
+                        break;
+                    }
+                }
+            }
+        }, (long) durationTicks);
     }
 }

--- a/weaponmechanics-platforms/paper/v1_21_R3/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R3.java
+++ b/weaponmechanics-platforms/paper/v1_21_R3/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R3.java
@@ -82,12 +82,17 @@ public class v1_21_R3 implements IWeaponCompatibility {
 
     @Override
     public TaskImplementation<Void> playAdsSettleAnimation(Player player, int durationTicks) {
-        ((CraftPlayer) player).getHandle().attackStrengthTicker = 0;
+        try {
+            java.lang.reflect.Field ticker = net.minecraft.world.entity.LivingEntity.class.getDeclaredField("attackStrengthTicker");
+            ticker.setAccessible(true);
+            ticker.set(((CraftPlayer) player).getHandle(), 0);
+        } catch (Exception ignored) {
+        }
 
         AttributeInstance attr = player.getAttribute(Attribute.ATTACK_SPEED);
         if (attr != null) {
             double requiredSpeed = 20.0 / Math.max(1, durationTicks);
-            double addValue = requiredSpeed - attr.getBaseValue();
+            double addValue = requiredSpeed - attr.getValue();
             for (AttributeModifier mod : new ArrayList<>(attr.getModifiers())) {
                 if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
                     attr.removeModifier(mod);

--- a/weaponmechanics-platforms/paper/v1_21_R4/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R4.java
+++ b/weaponmechanics-platforms/paper/v1_21_R4/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R4.java
@@ -1,5 +1,8 @@
 package me.deecaad.weaponmechanics.compatibility;
 
+import com.cjcrafter.foliascheduler.TaskImplementation;
+import me.deecaad.weaponmechanics.WeaponMechanics;
+import me.deecaad.weaponmechanics.wrappers.ZoomData;
 import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageSources;
@@ -7,10 +10,14 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.PositionMoveRotation;
 import net.minecraft.world.entity.Relative;
 import net.minecraft.world.phys.Vec3;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.craftbukkit.entity.CraftLivingEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -71,5 +78,35 @@ public class v1_21_R4 implements IWeaponCompatibility {
     @Override
     public void setKiller(org.bukkit.entity.LivingEntity victim, Player killer) {
         ((CraftLivingEntity) victim).getHandle().setLastHurtByPlayer(((CraftPlayer) killer).getHandle(), 100);
+    }
+
+    @Override
+    public TaskImplementation<Void> playAdsSettleAnimation(Player player, int durationTicks) {
+        ((CraftPlayer) player).getHandle().attackStrengthTicker = 0;
+
+        AttributeInstance attr = player.getAttribute(Attribute.ATTACK_SPEED);
+        if (attr != null) {
+            double requiredSpeed = 20.0 / Math.max(1, durationTicks);
+            double addValue = requiredSpeed - attr.getBaseValue();
+            for (AttributeModifier mod : new ArrayList<>(attr.getModifiers())) {
+                if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                    attr.removeModifier(mod);
+                    break;
+                }
+            }
+            attr.addModifier(new AttributeModifier(ZoomData.ADS_SPEED_MODIFIER_KEY, addValue, AttributeModifier.Operation.ADD_NUMBER));
+        }
+
+        return WeaponMechanics.getInstance().getFoliaScheduler().entity(player).runDelayed(() -> {
+            AttributeInstance a = player.getAttribute(Attribute.ATTACK_SPEED);
+            if (a != null) {
+                for (AttributeModifier mod : new ArrayList<>(a.getModifiers())) {
+                    if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                        a.removeModifier(mod);
+                        break;
+                    }
+                }
+            }
+        }, (long) durationTicks);
     }
 }

--- a/weaponmechanics-platforms/paper/v1_21_R4/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R4.java
+++ b/weaponmechanics-platforms/paper/v1_21_R4/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R4.java
@@ -82,12 +82,17 @@ public class v1_21_R4 implements IWeaponCompatibility {
 
     @Override
     public TaskImplementation<Void> playAdsSettleAnimation(Player player, int durationTicks) {
-        ((CraftPlayer) player).getHandle().attackStrengthTicker = 0;
+        try {
+            java.lang.reflect.Field ticker = net.minecraft.world.entity.LivingEntity.class.getDeclaredField("attackStrengthTicker");
+            ticker.setAccessible(true);
+            ticker.set(((CraftPlayer) player).getHandle(), 0);
+        } catch (Exception ignored) {
+        }
 
         AttributeInstance attr = player.getAttribute(Attribute.ATTACK_SPEED);
         if (attr != null) {
             double requiredSpeed = 20.0 / Math.max(1, durationTicks);
-            double addValue = requiredSpeed - attr.getBaseValue();
+            double addValue = requiredSpeed - attr.getValue();
             for (AttributeModifier mod : new ArrayList<>(attr.getModifiers())) {
                 if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
                     attr.removeModifier(mod);

--- a/weaponmechanics-platforms/paper/v1_21_R5/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R5.java
+++ b/weaponmechanics-platforms/paper/v1_21_R5/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R5.java
@@ -82,12 +82,17 @@ public class v1_21_R5 implements IWeaponCompatibility {
 
     @Override
     public TaskImplementation<Void> playAdsSettleAnimation(Player player, int durationTicks) {
-        ((CraftPlayer) player).getHandle().attackStrengthTicker = 0;
+        try {
+            java.lang.reflect.Field ticker = net.minecraft.world.entity.LivingEntity.class.getDeclaredField("attackStrengthTicker");
+            ticker.setAccessible(true);
+            ticker.set(((CraftPlayer) player).getHandle(), 0);
+        } catch (Exception ignored) {
+        }
 
         AttributeInstance attr = player.getAttribute(Attribute.ATTACK_SPEED);
         if (attr != null) {
             double requiredSpeed = 20.0 / Math.max(1, durationTicks);
-            double addValue = requiredSpeed - attr.getBaseValue();
+            double addValue = requiredSpeed - attr.getValue();
             for (AttributeModifier mod : new ArrayList<>(attr.getModifiers())) {
                 if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
                     attr.removeModifier(mod);

--- a/weaponmechanics-platforms/paper/v1_21_R5/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R5.java
+++ b/weaponmechanics-platforms/paper/v1_21_R5/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R5.java
@@ -1,5 +1,8 @@
 package me.deecaad.weaponmechanics.compatibility;
 
+import com.cjcrafter.foliascheduler.TaskImplementation;
+import me.deecaad.weaponmechanics.WeaponMechanics;
+import me.deecaad.weaponmechanics.wrappers.ZoomData;
 import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageSources;
@@ -7,10 +10,14 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.PositionMoveRotation;
 import net.minecraft.world.entity.Relative;
 import net.minecraft.world.phys.Vec3;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.craftbukkit.entity.CraftLivingEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -71,5 +78,35 @@ public class v1_21_R5 implements IWeaponCompatibility {
     @Override
     public void setKiller(org.bukkit.entity.LivingEntity victim, Player killer) {
         ((CraftLivingEntity) victim).getHandle().setLastHurtByPlayer(((CraftPlayer) killer).getHandle(), 100);
+    }
+
+    @Override
+    public TaskImplementation<Void> playAdsSettleAnimation(Player player, int durationTicks) {
+        ((CraftPlayer) player).getHandle().attackStrengthTicker = 0;
+
+        AttributeInstance attr = player.getAttribute(Attribute.ATTACK_SPEED);
+        if (attr != null) {
+            double requiredSpeed = 20.0 / Math.max(1, durationTicks);
+            double addValue = requiredSpeed - attr.getBaseValue();
+            for (AttributeModifier mod : new ArrayList<>(attr.getModifiers())) {
+                if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                    attr.removeModifier(mod);
+                    break;
+                }
+            }
+            attr.addModifier(new AttributeModifier(ZoomData.ADS_SPEED_MODIFIER_KEY, addValue, AttributeModifier.Operation.ADD_NUMBER));
+        }
+
+        return WeaponMechanics.getInstance().getFoliaScheduler().entity(player).runDelayed(() -> {
+            AttributeInstance a = player.getAttribute(Attribute.ATTACK_SPEED);
+            if (a != null) {
+                for (AttributeModifier mod : new ArrayList<>(a.getModifiers())) {
+                    if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                        a.removeModifier(mod);
+                        break;
+                    }
+                }
+            }
+        }, (long) durationTicks);
     }
 }

--- a/weaponmechanics-platforms/paper/v1_21_R6/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R6.java
+++ b/weaponmechanics-platforms/paper/v1_21_R6/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R6.java
@@ -1,5 +1,8 @@
 package me.deecaad.weaponmechanics.compatibility;
 
+import com.cjcrafter.foliascheduler.TaskImplementation;
+import me.deecaad.weaponmechanics.WeaponMechanics;
+import me.deecaad.weaponmechanics.wrappers.ZoomData;
 import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageSources;
@@ -7,10 +10,14 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.PositionMoveRotation;
 import net.minecraft.world.entity.Relative;
 import net.minecraft.world.phys.Vec3;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.craftbukkit.entity.CraftLivingEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -71,5 +78,35 @@ public class v1_21_R6 implements IWeaponCompatibility {
     @Override
     public void setKiller(org.bukkit.entity.LivingEntity victim, Player killer) {
         ((CraftLivingEntity) victim).getHandle().setLastHurtByPlayer(((CraftPlayer) killer).getHandle(), 100);
+    }
+
+    @Override
+    public TaskImplementation<Void> playAdsSettleAnimation(Player player, int durationTicks) {
+        ((CraftPlayer) player).getHandle().attackStrengthTicker = 0;
+
+        AttributeInstance attr = player.getAttribute(Attribute.ATTACK_SPEED);
+        if (attr != null) {
+            double requiredSpeed = 20.0 / Math.max(1, durationTicks);
+            double addValue = requiredSpeed - attr.getBaseValue();
+            for (AttributeModifier mod : new ArrayList<>(attr.getModifiers())) {
+                if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                    attr.removeModifier(mod);
+                    break;
+                }
+            }
+            attr.addModifier(new AttributeModifier(ZoomData.ADS_SPEED_MODIFIER_KEY, addValue, AttributeModifier.Operation.ADD_NUMBER));
+        }
+
+        return WeaponMechanics.getInstance().getFoliaScheduler().entity(player).runDelayed(() -> {
+            AttributeInstance a = player.getAttribute(Attribute.ATTACK_SPEED);
+            if (a != null) {
+                for (AttributeModifier mod : new ArrayList<>(a.getModifiers())) {
+                    if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                        a.removeModifier(mod);
+                        break;
+                    }
+                }
+            }
+        }, (long) durationTicks);
     }
 }

--- a/weaponmechanics-platforms/paper/v1_21_R6/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R6.java
+++ b/weaponmechanics-platforms/paper/v1_21_R6/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R6.java
@@ -82,12 +82,17 @@ public class v1_21_R6 implements IWeaponCompatibility {
 
     @Override
     public TaskImplementation<Void> playAdsSettleAnimation(Player player, int durationTicks) {
-        ((CraftPlayer) player).getHandle().attackStrengthTicker = 0;
+        try {
+            java.lang.reflect.Field ticker = net.minecraft.world.entity.LivingEntity.class.getDeclaredField("attackStrengthTicker");
+            ticker.setAccessible(true);
+            ticker.set(((CraftPlayer) player).getHandle(), 0);
+        } catch (Exception ignored) {
+        }
 
         AttributeInstance attr = player.getAttribute(Attribute.ATTACK_SPEED);
         if (attr != null) {
             double requiredSpeed = 20.0 / Math.max(1, durationTicks);
-            double addValue = requiredSpeed - attr.getBaseValue();
+            double addValue = requiredSpeed - attr.getValue();
             for (AttributeModifier mod : new ArrayList<>(attr.getModifiers())) {
                 if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
                     attr.removeModifier(mod);

--- a/weaponmechanics-platforms/paper/v1_21_R7/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R7.java
+++ b/weaponmechanics-platforms/paper/v1_21_R7/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R7.java
@@ -1,5 +1,8 @@
 package me.deecaad.weaponmechanics.compatibility;
 
+import com.cjcrafter.foliascheduler.TaskImplementation;
+import me.deecaad.weaponmechanics.WeaponMechanics;
+import me.deecaad.weaponmechanics.wrappers.ZoomData;
 import net.minecraft.network.protocol.game.ClientboundPlayerPositionPacket;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageSources;
@@ -7,10 +10,14 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.PositionMoveRotation;
 import net.minecraft.world.entity.Relative;
 import net.minecraft.world.phys.Vec3;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.craftbukkit.entity.CraftLivingEntity;
 import org.bukkit.craftbukkit.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -71,5 +78,35 @@ public class v1_21_R7 implements IWeaponCompatibility {
     @Override
     public void setKiller(org.bukkit.entity.LivingEntity victim, Player killer) {
         ((CraftLivingEntity) victim).getHandle().setLastHurtByPlayer(((CraftPlayer) killer).getHandle(), 100);
+    }
+
+    @Override
+    public TaskImplementation<Void> playAdsSettleAnimation(Player player, int durationTicks) {
+        ((CraftPlayer) player).getHandle().attackStrengthTicker = 0;
+
+        AttributeInstance attr = player.getAttribute(Attribute.ATTACK_SPEED);
+        if (attr != null) {
+            double requiredSpeed = 20.0 / Math.max(1, durationTicks);
+            double addValue = requiredSpeed - attr.getBaseValue();
+            for (AttributeModifier mod : new ArrayList<>(attr.getModifiers())) {
+                if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                    attr.removeModifier(mod);
+                    break;
+                }
+            }
+            attr.addModifier(new AttributeModifier(ZoomData.ADS_SPEED_MODIFIER_KEY, addValue, AttributeModifier.Operation.ADD_NUMBER));
+        }
+
+        return WeaponMechanics.getInstance().getFoliaScheduler().entity(player).runDelayed(() -> {
+            AttributeInstance a = player.getAttribute(Attribute.ATTACK_SPEED);
+            if (a != null) {
+                for (AttributeModifier mod : new ArrayList<>(a.getModifiers())) {
+                    if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
+                        a.removeModifier(mod);
+                        break;
+                    }
+                }
+            }
+        }, (long) durationTicks);
     }
 }

--- a/weaponmechanics-platforms/paper/v1_21_R7/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R7.java
+++ b/weaponmechanics-platforms/paper/v1_21_R7/src/main/java/me/deecaad/weaponmechanics/compatibility/v1_21_R7.java
@@ -82,12 +82,17 @@ public class v1_21_R7 implements IWeaponCompatibility {
 
     @Override
     public TaskImplementation<Void> playAdsSettleAnimation(Player player, int durationTicks) {
-        ((CraftPlayer) player).getHandle().attackStrengthTicker = 0;
+        try {
+            java.lang.reflect.Field ticker = net.minecraft.world.entity.LivingEntity.class.getDeclaredField("attackStrengthTicker");
+            ticker.setAccessible(true);
+            ticker.set(((CraftPlayer) player).getHandle(), 0);
+        } catch (Exception ignored) {
+        }
 
         AttributeInstance attr = player.getAttribute(Attribute.ATTACK_SPEED);
         if (attr != null) {
             double requiredSpeed = 20.0 / Math.max(1, durationTicks);
-            double addValue = requiredSpeed - attr.getBaseValue();
+            double addValue = requiredSpeed - attr.getValue();
             for (AttributeModifier mod : new ArrayList<>(attr.getModifiers())) {
                 if (ZoomData.ADS_SPEED_MODIFIER_KEY.equals(mod.getKey())) {
                     attr.removeModifier(mod);


### PR DESCRIPTION
## Summary

- Adds `Scope.ADS_Speed` (in ticks): after scoping in, the weapon retains hipfire accuracy until the timer expires, then transitions to full ADS accuracy.
- During settling, the vanilla attack-cooldown animation plays (item drops and rises), synced to the ADS_Speed duration.
- Fixes attribute modifier calculation to account for item-level `ATTACK_SPEED` modifiers (e.g. weapons with `ATTACK_SPEED 100`).
- Fixes `AmmoConverter` compile error after `WeaponConverter` gained a new `itemModel` parameter.

## Config example

```yaml
Scope:
  Trigger:
    Main_Hand: LEFT_CLICK
  Zoom_Amount: 2.0
  ADS_Speed: 20  # 1 second settling before full ADS accuracy kicks in
```

## Files changed

| File | Change |
|------|--------|
| `ZoomData.java` | Settling state: `isSettling`, `startSettling`, `stopSettling`, task ref |
| `AModifyWhen.java` | Skip `Zooming` modifier while `isSettling()` |
| `ScopeHandler.java` | Read/validate `ADS_Speed`, trigger settling on zoom in/out |
| `IWeaponCompatibility.java` | New `playAdsSettleAnimation(Player, int)` method |
| `v1_21_R2` – `v1_21_R7` | NMS implementation using `attackStrengthTicker` + `ATTACK_SPEED` attribute |
| `AmmoConverter.java` | Fix 5-arg super() call after WeaponConverter gained `itemModel` param |