### PR TITLE
Guard stat persistence when database is unavailable

### DIFF
--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/WeaponMechanics.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/WeaponMechanics.java
@@ -485,6 +485,10 @@ public class WeaponMechanics extends MechanicsPlugin {
         return database;
     }
 
+    public @Nullable Database getDatabaseOrNull() {
+        return database;
+    }
+
     public @NotNull ProjectileSpawner getProjectileSpawner() {
         if (projectileSpawner == null)
             throw new UninitializedPropertyAccessException();

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/stats/StatsHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/stats/StatsHandler.java
@@ -1,7 +1,6 @@
 package me.deecaad.weaponmechanics.weapon.stats;
 
 import me.deecaad.core.database.Database;
-import me.deecaad.core.utils.LogLevel;
 import me.deecaad.weaponmechanics.WeaponMechanics;
 import me.deecaad.weaponmechanics.weapon.WeaponHandler;
 import me.deecaad.weaponmechanics.wrappers.PlayerWrapper;
@@ -27,12 +26,12 @@ public class StatsHandler {
      * @param playerWrapper the player wrapper
      */
     public void load(PlayerWrapper playerWrapper) {
-        Database database = WeaponMechanics.getInstance().getDatabase();
-        if (database.isClosed())
-            throw new IllegalArgumentException("Tried to load data when database was closed");
-
         StatsData statsData = playerWrapper.getStatsDataUnsafe();
         if (statsData == null)
+            return;
+
+        Database database = WeaponMechanics.getInstance().getDatabaseOrNull();
+        if (database == null || database.isClosed())
             return;
 
         if (statsData.isSync())
@@ -48,13 +47,13 @@ public class StatsHandler {
      * @param forceSync true means that saving is forced to be sync (used on disable)
      */
     public void save(PlayerWrapper playerWrapper, boolean forceSync) {
-        Database database = WeaponMechanics.getInstance().getDatabase();
-        if (database.isClosed())
-            throw new IllegalArgumentException("Tried to save data when database was closed");
-
         StatsData statsData = playerWrapper.getStatsData();
         // This might be null if sync didn't occur...
         if (statsData == null)
+            return;
+
+        Database database = WeaponMechanics.getInstance().getDatabaseOrNull();
+        if (database == null || database.isClosed())
             return;
 
         database.executeUpdate(forceSync, getSaveStrings(playerWrapper));


### PR DESCRIPTION
## Summary

- Avoid calling `getDatabase()` before confirming player stats are enabled or synced.
- Add a nullable database accessor for lifecycle windows where reload/disable leaves the database absent.
- Skip stat load/save when the database is disabled, unavailable, or already closed, preventing quit/join event crashes.

Fixes WeaponMechanics/WeaponMechanicsCosmeticsWiki#46.

## Verification

- `git diff --check`
- `./gradlew weaponmechanics-core:compileJava` could not run in this environment because no Java runtime is installed (`Unable to locate a Java Runtime`).