### PR TITLE
fix: skip stats save before database access when stats are not loaded

### DIFF
--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/stats/StatsHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/stats/StatsHandler.java
@@ -48,14 +48,14 @@ public class StatsHandler {
      * @param forceSync true means that saving is forced to be sync (used on disable)
      */
     public void save(PlayerWrapper playerWrapper, boolean forceSync) {
-        Database database = WeaponMechanics.getInstance().getDatabase();
-        if (database.isClosed())
-            throw new IllegalArgumentException("Tried to save data when database was closed");
-
         StatsData statsData = playerWrapper.getStatsData();
         // This might be null if sync didn't occur...
         if (statsData == null)
             return;
+
+        Database database = WeaponMechanics.getInstance().getDatabase();
+        if (database.isClosed())
+            throw new IllegalArgumentException("Tried to save data when database was closed");
 
         database.executeUpdate(forceSync, getSaveStrings(playerWrapper));
     }


### PR DESCRIPTION
## Changes

- Avoid touching `WeaponMechanics.getDatabase()` when player stats were not loaded/synced yet.
- Keeps the existing no-op behavior for unsynced stats data before attempting a database save.

## Why

`PlayerQuitEvent` can call `StatsHandler.save()` during reload/disconnect lifecycle paths where a player wrapper exists but stats data is not synced. The method already intended to return when stats were unavailable, but it accessed the database before that guard, which could throw `UninitializedPropertyAccessException`.

Fixes WeaponMechanics/WeaponMechanicsCosmeticsWiki#46.

## Testing

- `git diff --check`


