### PR TITLE
Add scope movement speed attributes

### DIFF
--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/scope/ScopeHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/scope/ScopeHandler.java
@@ -38,6 +38,7 @@ import org.vivecraft.api.VRAPI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalDouble;
 
 @SearcherFilter(SearchMode.ON_DEMAND)
 public class ScopeHandler implements IValidator, TriggerListener {
@@ -184,6 +185,7 @@ public class ScopeHandler implements IValidator, TriggerListener {
 
                 zoomData.setScopeData(weaponTitle, weaponStack);
 
+                useMovementSpeedModifier(weaponTitle, entityWrapper, zoomData);
                 updateZoom(entityWrapper, zoomData, weaponScopeEvent.getZoomAmount());
                 zoomData.setZoomStacks(zoomStack);
 
@@ -217,6 +219,7 @@ public class ScopeHandler implements IValidator, TriggerListener {
         }
 
         zoomData.setScopeData(weaponTitle, weaponStack);
+        useMovementSpeedModifier(weaponTitle, entityWrapper, zoomData);
         updateZoom(entityWrapper, zoomData, weaponScopeEvent.getZoomAmount());
 
         if (weaponScopeEvent.getMechanics() != null)
@@ -251,6 +254,7 @@ public class ScopeHandler implements IValidator, TriggerListener {
 
         zoomData.setScopeData(null, null);
 
+        restoreMovementSpeed(entityWrapper, zoomData);
         updateZoom(entityWrapper, zoomData, weaponScopeEvent.getZoomAmount());
         zoomData.setZoomStacks(0);
 
@@ -261,6 +265,51 @@ public class ScopeHandler implements IValidator, TriggerListener {
         useNightVision(entityWrapper, zoomData, false);
 
         return true;
+    }
+
+    private void useMovementSpeedModifier(String weaponTitle, EntityWrapper entityWrapper, ZoomData zoomData) {
+        if (!(entityWrapper.getEntity() instanceof Player player))
+            return;
+
+        OptionalDouble speedModifier = getMovementSpeedModifier(weaponTitle);
+        if (speedModifier.isEmpty())
+            return;
+
+        if (zoomData.hasOriginalWalkSpeed())
+            return;
+
+        zoomData.setOriginalWalkSpeed(player.getWalkSpeed());
+        float modifiedSpeed = (float) (player.getWalkSpeed() + speedModifier.getAsDouble());
+        player.setWalkSpeed(Math.max(-1.0f, Math.min(1.0f, modifiedSpeed)));
+    }
+
+    public void restoreMovementSpeed(EntityWrapper entityWrapper, ZoomData zoomData) {
+        if (!zoomData.hasOriginalWalkSpeed() || !(entityWrapper.getEntity() instanceof Player player))
+            return;
+
+        player.setWalkSpeed(zoomData.removeOriginalWalkSpeed());
+    }
+
+    private OptionalDouble getMovementSpeedModifier(String weaponTitle) {
+        List<?> attributes = WeaponMechanics.getInstance().getWeaponConfigurations().getObject(weaponTitle + ".Scope.Attributes", List.class);
+        if (attributes == null)
+            return OptionalDouble.empty();
+
+        for (Object attribute : attributes) {
+            String[] split = splitAttribute(attribute);
+            if (split.length < 2)
+                continue;
+
+            if (!"movement_speed".equals(normalizeAttributeName(split[0])))
+                continue;
+
+            try {
+                return OptionalDouble.of(Double.parseDouble(split[1]));
+            } catch (NumberFormatException ignored) {
+            }
+        }
+
+        return OptionalDouble.empty();
     }
 
     /**
@@ -372,5 +421,42 @@ public class ScopeHandler implements IValidator, TriggerListener {
             // Convert to millis
             configuration.set(data.getKey() + ".Shoot_Delay_After_Scope", shootDelayAfterScope * 50);
         }
+
+        List<?> attributes = data.of("Attributes").get(List.class).orElse(null);
+        if (attributes != null) {
+            for (Object attribute : attributes) {
+                String[] split = splitAttribute(attribute);
+
+                if (split.length < 2)
+                    throw data.exception("Attributes", "Expected attributes to use the format '<attribute> <amount>'",
+                        "For example, 'movement_speed -0.1' slows the player while scoped.");
+
+                if (!"movement_speed".equals(normalizeAttributeName(split[0])))
+                    throw data.exception("Attributes", "Only movement_speed is supported for scope attributes.",
+                        "Use weapon item attributes for always-active item attribute modifiers.");
+
+                try {
+                    Double.parseDouble(split[1]);
+                } catch (NumberFormatException ex) {
+                    throw data.exception("Attributes", "Expected the movement_speed amount to be a number.",
+                        "For example, 'movement_speed -0.1' slows the player while scoped.");
+                }
+            }
+        }
+    }
+
+    private static String[] splitAttribute(Object attribute) {
+        return attribute.toString().trim()
+            .replaceFirst("--", " -")
+            .split("\\s+");
+    }
+
+    private static String normalizeAttributeName(String attributeName) {
+        return attributeName.toLowerCase()
+            .replace("minecraft:", "")
+            .replace("generic.", "")
+            .replace("generic_", "")
+            .replace('.', '_')
+            .replace('-', '_');
     }
 }

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/wrappers/ZoomData.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/wrappers/ZoomData.java
@@ -19,6 +19,7 @@ public class ZoomData {
     private double zoomAmount;
     private int zoomStacks;
     private boolean zoomNightVision;
+    private Float originalWalkSpeed;
     private ItemStack scopeWeaponStack;
     private String scopeWeaponTitle;
 
@@ -100,6 +101,23 @@ public class ZoomData {
         this.zoomNightVision = zoomNightVision;
     }
 
+    public boolean hasOriginalWalkSpeed() {
+        return originalWalkSpeed != null;
+    }
+
+    public void setOriginalWalkSpeed(float originalWalkSpeed) {
+        this.originalWalkSpeed = originalWalkSpeed;
+    }
+
+    public float removeOriginalWalkSpeed() {
+        if (originalWalkSpeed == null)
+            return 0.2f;
+
+        float walkSpeed = originalWalkSpeed;
+        originalWalkSpeed = null;
+        return walkSpeed;
+    }
+
     public void ifZoomingForceZoomOut() {
         if (isZooming()) {
 
@@ -110,6 +128,7 @@ public class ZoomData {
             EntityWrapper entityWrapper = handData.getEntityWrapper();
 
             ScopeHandler scopeHandler = WeaponMechanics.getInstance().getWeaponHandler().getScopeHandler();
+            scopeHandler.restoreMovementSpeed(entityWrapper, this);
             scopeHandler.updateZoom(entityWrapper, this, 0);
             setZoomStacks(0);
             scopeHandler.useNightVision(entityWrapper, this, false);


### PR DESCRIPTION
## Summary

- Adds support for `Scope.Attributes` entries targeting `movement_speed` / `generic_movement_speed`.
- Applies the configured walk speed modifier while a player is scoped, then restores their original walk speed on normal or forced zoom-out.
- Validates scope attributes so unsupported attributes or non-numeric values fail config validation clearly.

This addresses the paid feature request in #233.

Example:

```yaml
Scope:
  Attributes:
    - "movement_speed -0.1"
```

The requested `GENERIC_MOVEMENT_SPEED--0.1000` form is also accepted and treated as `-0.1000`.

## Verification

- `git diff --check`
- `./gradlew weaponmechanics-core:compileJava -Dorg.gradle.java.home=/tmp/jdk21/Contents/Home`
