### PR TITLE
Add shoot auto reload toggle

### DIFF
--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/shoot/FullAutoTask.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/shoot/FullAutoTask.java
@@ -175,7 +175,7 @@ public class FullAutoTask implements Consumer<TaskImplementation<Void>> {
             handData.setFullAutoTask(null, null);
 
             if (ammoLeft == 0) {
-                weaponHandler.getShootHandler().startReloadIfBothWeaponsEmpty(entityWrapper, weaponTitle, taskReference, mainHand ? EquipmentSlot.HAND : EquipmentSlot.OFF_HAND, dualWield, false);
+                weaponHandler.getShootHandler().startReloadIfBothWeaponsEmpty(entityWrapper, weaponTitle, taskReference, mainHand ? EquipmentSlot.HAND : EquipmentSlot.OFF_HAND, dualWield, false, false);
             } else {
                 weaponHandler.getShootHandler().doShootFirearmActions(entityWrapper, weaponTitle, taskReference, handData, mainHand ? EquipmentSlot.HAND : EquipmentSlot.OFF_HAND);
             }

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/shoot/ShootHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/shoot/ShootHandler.java
@@ -260,7 +260,7 @@ public class ShootHandler implements IValidator, TriggerListener {
         }
 
         if (reloadHandler.getAmmoLeft(weaponStack, weaponTitle) == 0) {
-            startReloadIfBothWeaponsEmpty(entityWrapper, weaponTitle, weaponStack, slot, dualWield, false);
+            startReloadIfBothWeaponsEmpty(entityWrapper, weaponTitle, weaponStack, slot, dualWield, false, false);
         } else {
             doShootFirearmActions(entityWrapper, weaponTitle, weaponStack, handData, slot);
         }
@@ -327,7 +327,7 @@ public class ShootHandler implements IValidator, TriggerListener {
                     scheduledTask.cancel();
 
                     if (reloadHandler.getAmmoLeft(taskReference, weaponTitle) == 0) {
-                        startReloadIfBothWeaponsEmpty(entityWrapper, weaponTitle, taskReference, slot, dualWield, false);
+                        startReloadIfBothWeaponsEmpty(entityWrapper, weaponTitle, taskReference, slot, dualWield, false, false);
                     } else {
                         doShootFirearmActions(entityWrapper, weaponTitle, taskReference, handData, slot);
                     }
@@ -478,8 +478,20 @@ public class ShootHandler implements IValidator, TriggerListener {
     }
 
     public void startReloadIfBothWeaponsEmpty(EntityWrapper entityWrapper, String weaponTitle, ItemStack weaponStack, EquipmentSlot slot, boolean dualWield, boolean isReloadLoop) {
+        startReloadIfBothWeaponsEmpty(entityWrapper, weaponTitle, weaponStack, slot, dualWield, isReloadLoop, true);
+    }
+
+    public void startReloadIfBothWeaponsEmpty(EntityWrapper entityWrapper, String weaponTitle, ItemStack weaponStack, EquipmentSlot slot, boolean dualWield, boolean isReloadLoop, boolean triggerOutOfAmmoMechanics) {
         if (entityWrapper.isReloading())
             return;
+
+        Configuration config = WeaponMechanics.getInstance().getWeaponConfigurations();
+        if (!config.getBoolean(weaponTitle + ".Shoot.Auto_Reload", true)) {
+            if (triggerOutOfAmmoMechanics)
+                useOutOfAmmoMechanics(entityWrapper, weaponTitle, weaponStack);
+            weaponHandler.getSkinHandler().tryUse(entityWrapper, weaponTitle, weaponStack, slot);
+            return;
+        }
 
         ReloadHandler reloadHandler = weaponHandler.getReloadHandler();
 
@@ -508,6 +520,12 @@ public class ShootHandler implements IValidator, TriggerListener {
                 weaponHandler.getSkinHandler().tryUse(entityWrapper, weaponTitle, weaponStack, slot);
             }
         }
+    }
+
+    private void useOutOfAmmoMechanics(EntityWrapper entityWrapper, String weaponTitle, ItemStack weaponStack) {
+        MechanicManager outOfAmmoMechanics = WeaponMechanics.getInstance().getWeaponConfigurations().getObject(weaponTitle + ".Shoot.Out_Of_Ammo_Mechanics", MechanicManager.class);
+        if (outOfAmmoMechanics != null)
+            outOfAmmoMechanics.use(new CastData(entityWrapper.getEntity(), weaponTitle, weaponStack));
     }
 
     /**
@@ -807,6 +825,8 @@ public class ShootHandler implements IValidator, TriggerListener {
         }
 
         configuration.set(data.getKey() + ".Reset_Fall_Distance", data.of("Reset_Fall_Distance").getBool().orElse(false));
+        configuration.set(data.getKey() + ".Auto_Reload", data.of("Auto_Reload").getBool().orElse(true));
+        configuration.set(data.getKey() + ".Out_Of_Ammo_Mechanics", data.of("Out_Of_Ammo_Mechanics").serialize(MechanicManager.class).orElse(null));
 
         if (Bukkit.getPluginManager().getPlugin("Vivecraft_Spigot_Extensions") != null) {
             configuration.set(data.getKey() + ".Haptic", data.of("Haptic").serialize(HapticSerializer.class).orElse(null));


### PR DESCRIPTION
## Summary

- Adds `Shoot.Auto_Reload`, defaulting to `true`, so existing weapon configs keep their current behavior.
- Adds `Shoot.Out_Of_Ammo_Mechanics`, which runs when a player tries to shoot an already-empty weapon.
- Keeps normal last-shot behavior quiet, so out-of-ammo mechanics do not fire just because a valid shot consumed the final round.

This addresses the paid feature request in #582.

Example:

```yaml
Shoot:
  Auto_Reload: false
  Out_Of_Ammo_Mechanics:
    - "Sound{sound=block.lever.click, volume=0.6, pitch=1.8}"
```

## Verification

- `git diff --check`
- `./gradlew weaponmechanics-core:compileJava -Dorg.gradle.java.home=/tmp/jdk21/Contents/Home`
