### PR TITLE
Add scoped movement speed attribute modifiers

### DIFF
--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/scope/ScopeHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/scope/ScopeHandler.java
@@ -25,6 +25,10 @@ import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
+import org.bukkit.NamespacedKey;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -38,9 +42,12 @@ import org.vivecraft.api.VRAPI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalDouble;
 
 @SearcherFilter(SearchMode.ON_DEMAND)
 public class ScopeHandler implements IValidator, TriggerListener {
+
+    private static final NamespacedKey SCOPE_MOVEMENT_SPEED_KEY = new NamespacedKey(WeaponMechanics.getInstance(), "scope_movement_speed");
 
     private WeaponHandler weaponHandler;
 
@@ -184,6 +191,7 @@ public class ScopeHandler implements IValidator, TriggerListener {
 
                 zoomData.setScopeData(weaponTitle, weaponStack);
 
+                useMovementSpeedModifier(weaponTitle, entityWrapper, zoomData);
                 updateZoom(entityWrapper, zoomData, weaponScopeEvent.getZoomAmount());
                 zoomData.setZoomStacks(zoomStack);
 
@@ -217,6 +225,7 @@ public class ScopeHandler implements IValidator, TriggerListener {
         }
 
         zoomData.setScopeData(weaponTitle, weaponStack);
+        useMovementSpeedModifier(weaponTitle, entityWrapper, zoomData);
         updateZoom(entityWrapper, zoomData, weaponScopeEvent.getZoomAmount());
 
         if (weaponScopeEvent.getMechanics() != null)
@@ -251,6 +260,7 @@ public class ScopeHandler implements IValidator, TriggerListener {
 
         zoomData.setScopeData(null, null);
 
+        restoreMovementSpeed(entityWrapper, zoomData);
         updateZoom(entityWrapper, zoomData, weaponScopeEvent.getZoomAmount());
         zoomData.setZoomStacks(0);
 
@@ -288,6 +298,66 @@ public class ScopeHandler implements IValidator, TriggerListener {
         );
 
         PacketEvents.getAPI().getPlayerManager().sendPacket(player, abilities);
+    }
+
+    private void useMovementSpeedModifier(String weaponTitle, EntityWrapper entityWrapper, ZoomData zoomData) {
+        if (!(entityWrapper.getEntity() instanceof Player player))
+            return;
+
+        OptionalDouble speedModifier = getMovementSpeedModifier(weaponTitle);
+        if (speedModifier.isEmpty())
+            return;
+
+        AttributeInstance attribute = player.getAttribute(Attribute.MOVEMENT_SPEED);
+        if (attribute == null)
+            return;
+
+        removeMovementSpeedModifier(attribute);
+
+        AttributeModifier modifier = new AttributeModifier(SCOPE_MOVEMENT_SPEED_KEY, speedModifier.getAsDouble(), AttributeModifier.Operation.ADD_NUMBER);
+        attribute.addModifier(modifier);
+        zoomData.setHasMovementSpeedModifier(true);
+    }
+
+    public void restoreMovementSpeed(EntityWrapper entityWrapper, ZoomData zoomData) {
+        if (!zoomData.hasMovementSpeedModifier() || !(entityWrapper.getEntity() instanceof Player player))
+            return;
+
+        AttributeInstance attribute = player.getAttribute(Attribute.MOVEMENT_SPEED);
+        if (attribute != null)
+            removeMovementSpeedModifier(attribute);
+
+        zoomData.setHasMovementSpeedModifier(false);
+    }
+
+    private void removeMovementSpeedModifier(AttributeInstance attribute) {
+        for (AttributeModifier modifier : attribute.getModifiers()) {
+            if (SCOPE_MOVEMENT_SPEED_KEY.equals(modifier.getKey())) {
+                attribute.removeModifier(modifier);
+            }
+        }
+    }
+
+    private OptionalDouble getMovementSpeedModifier(String weaponTitle) {
+        List<?> attributes = WeaponMechanics.getInstance().getWeaponConfigurations().getObject(weaponTitle + ".Scope.Attributes", List.class);
+        if (attributes == null)
+            return OptionalDouble.empty();
+
+        for (Object attribute : attributes) {
+            String[] split = splitAttribute(attribute);
+            if (split.length < 2)
+                continue;
+
+            if (!"movement_speed".equals(normalizeAttributeName(split[0])))
+                continue;
+
+            try {
+                return OptionalDouble.of(Double.parseDouble(split[1]));
+            } catch (NumberFormatException ignored) {
+            }
+        }
+
+        return OptionalDouble.empty();
     }
 
     /**
@@ -372,5 +442,42 @@ public class ScopeHandler implements IValidator, TriggerListener {
             // Convert to millis
             configuration.set(data.getKey() + ".Shoot_Delay_After_Scope", shootDelayAfterScope * 50);
         }
+
+        List<?> attributes = data.of("Attributes").get(List.class).orElse(null);
+        if (attributes != null) {
+            for (Object attribute : attributes) {
+                String[] split = splitAttribute(attribute);
+
+                if (split.length < 2)
+                    throw data.exception("Attributes", "Expected attributes to use the format '<attribute> <amount>'",
+                        "For example, 'movement_speed -0.1' slows the player while scoped.");
+
+                if (!"movement_speed".equals(normalizeAttributeName(split[0])))
+                    throw data.exception("Attributes", "Only movement_speed is supported for scope attributes.",
+                        "Use weapon item attributes for always-active item attribute modifiers.");
+
+                try {
+                    Double.parseDouble(split[1]);
+                } catch (NumberFormatException ex) {
+                    throw data.exception("Attributes", "Expected the movement_speed amount to be a number.",
+                        "For example, 'movement_speed -0.1' slows the player while scoped.");
+                }
+            }
+        }
+    }
+
+    private static String[] splitAttribute(Object attribute) {
+        return attribute.toString().trim()
+            .replaceFirst("--", " -")
+            .split("\\s+");
+    }
+
+    private static String normalizeAttributeName(String attributeName) {
+        return attributeName.toLowerCase()
+            .replace("minecraft:", "")
+            .replace("generic.", "")
+            .replace("generic_", "")
+            .replace('.', '_')
+            .replace('-', '_');
     }
 }

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/wrappers/ZoomData.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/wrappers/ZoomData.java
@@ -19,6 +19,7 @@ public class ZoomData {
     private double zoomAmount;
     private int zoomStacks;
     private boolean zoomNightVision;
+    private boolean hasMovementSpeedModifier;
     private ItemStack scopeWeaponStack;
     private String scopeWeaponTitle;
 
@@ -100,6 +101,14 @@ public class ZoomData {
         this.zoomNightVision = zoomNightVision;
     }
 
+    public boolean hasMovementSpeedModifier() {
+        return hasMovementSpeedModifier;
+    }
+
+    public void setHasMovementSpeedModifier(boolean hasMovementSpeedModifier) {
+        this.hasMovementSpeedModifier = hasMovementSpeedModifier;
+    }
+
     public void ifZoomingForceZoomOut() {
         if (isZooming()) {
 
@@ -110,6 +119,7 @@ public class ZoomData {
             EntityWrapper entityWrapper = handData.getEntityWrapper();
 
             ScopeHandler scopeHandler = WeaponMechanics.getInstance().getWeaponHandler().getScopeHandler();
+            scopeHandler.restoreMovementSpeed(entityWrapper, this);
             scopeHandler.updateZoom(entityWrapper, this, 0);
             setZoomStacks(0);
             scopeHandler.useNightVision(entityWrapper, this, false);


### PR DESCRIPTION
## Summary
- add `Scope.Attributes` support for scoped `movement_speed` modifiers
- apply/remove a real `AttributeModifier` on `Attribute.MOVEMENT_SPEED` while zoomed
- restore the modifier on zoom-out and force zoom-out
- validate the new scope attribute entries during config parsing

## Why
Issue #233 asks for the same `GENERIC_MOVEMENT_SPEED` style capability while scoped. This implementation keeps the movement penalty separate from the player raw walk speed/FOV packet flow by using an attribute modifier instead of `Player#setWalkSpeed()`.

## Example
```yaml
Scope:
  Attributes:
    - "GENERIC_MOVEMENT_SPEED--0.1000"
```

## Validation
- `./gradlew :weaponmechanics-core:compileJava`
- `./gradlew :weaponmechanics-core:test --rerun-tasks`

Closes #233