### PR TITLE
Fix stats persistence when database is unavailable

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,10 @@ foliaScheduler = "0.7.5"
 gson = "2.13.1"
 hikariCp = "5.1.0"
 jsonSimple = "1.1.1"
+junitJupiter = "5.13.1"
+junitPlatform = "1.13.1"
 kotlin = "1.9.23"
+mockito = "5.18.0"
 xSeries = "13.6.0"
 
 
@@ -52,5 +55,8 @@ foliaScheduler           = { module = "com.cjcrafter:foliascheduler", version.re
 gson                     = { module = "com.google.code.gson:gson", version.ref = "gson" }
 hikariCp                 = { module = "com.zaxxer:HikariCP", version.ref = "hikariCp" }
 jsonSimple               = { module = "com.googlecode.json-simple:json-simple", version.ref = "jsonSimple" }
+junitJupiter             = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junitJupiter" }
+junitPlatformLauncher    = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatform" }
 kotlinStdlib             = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+mockitoCore              = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 xSeries                  = { module = "com.github.cryptomorin:XSeries", version.ref = "xSeries" }

--- a/weaponmechanics-core/build.gradle.kts
+++ b/weaponmechanics-core/build.gradle.kts
@@ -32,8 +32,12 @@ dependencies {
 
     // Testing dependencies
     testImplementation(libs.paper)
+    testImplementation(libs.mechanicsCore)
     testImplementation(libs.annotations)
     testImplementation(libs.foliaScheduler)
+    testImplementation(libs.junitJupiter)
+    testImplementation(libs.mockitoCore)
+    testRuntimeOnly(libs.junitPlatformLauncher)
 }
 
 

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/WeaponMechanics.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/WeaponMechanics.java
@@ -485,6 +485,10 @@ public class WeaponMechanics extends MechanicsPlugin {
         return database;
     }
 
+    public @Nullable Database getDatabaseOrNull() {
+        return database;
+    }
+
     public @NotNull ProjectileSpawner getProjectileSpawner() {
         if (projectileSpawner == null)
             throw new UninitializedPropertyAccessException();

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/stats/StatsHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/stats/StatsHandler.java
@@ -6,18 +6,26 @@ import me.deecaad.weaponmechanics.WeaponMechanics;
 import me.deecaad.weaponmechanics.weapon.WeaponHandler;
 import me.deecaad.weaponmechanics.wrappers.PlayerWrapper;
 import me.deecaad.weaponmechanics.wrappers.StatsData;
+import org.jetbrains.annotations.Nullable;
 
 import java.sql.SQLException;
 import java.util.*;
+import java.util.function.Supplier;
 
 public class StatsHandler {
 
     private WeaponHandler weaponHandler;
+    private final Supplier<Database> databaseSupplier;
     private StringBuilder generatedReplaceWeaponStats;
     private StringBuilder generatedReplacePlayerStats;
 
     public StatsHandler(WeaponHandler weaponHandler) {
+        this(weaponHandler, () -> WeaponMechanics.getInstance().getDatabaseOrNull());
+    }
+
+    StatsHandler(WeaponHandler weaponHandler, Supplier<Database> databaseSupplier) {
         this.weaponHandler = weaponHandler;
+        this.databaseSupplier = databaseSupplier;
         generateReplaces();
     }
 
@@ -27,16 +35,16 @@ public class StatsHandler {
      * @param playerWrapper the player wrapper
      */
     public void load(PlayerWrapper playerWrapper) {
-        Database database = WeaponMechanics.getInstance().getDatabase();
-        if (database.isClosed())
-            throw new IllegalArgumentException("Tried to load data when database was closed");
-
         StatsData statsData = playerWrapper.getStatsDataUnsafe();
         if (statsData == null)
             return;
 
         if (statsData.isSync())
             throw new IllegalArgumentException("Tried to load data to already synced stats data");
+
+        Database database = getOpenDatabase();
+        if (database == null)
+            return;
 
         fetchAndInsertPlayerStats(database, playerWrapper.getPlayer().getUniqueId(), statsData);
     }
@@ -48,16 +56,24 @@ public class StatsHandler {
      * @param forceSync true means that saving is forced to be sync (used on disable)
      */
     public void save(PlayerWrapper playerWrapper, boolean forceSync) {
-        Database database = WeaponMechanics.getInstance().getDatabase();
-        if (database.isClosed())
-            throw new IllegalArgumentException("Tried to save data when database was closed");
-
         StatsData statsData = playerWrapper.getStatsData();
         // This might be null if sync didn't occur...
         if (statsData == null)
             return;
 
+        Database database = getOpenDatabase();
+        if (database == null)
+            return;
+
         database.executeUpdate(forceSync, getSaveStrings(playerWrapper));
+    }
+
+    private @Nullable Database getOpenDatabase() {
+        Database database = databaseSupplier.get();
+        if (database == null || database.isClosed())
+            return null;
+
+        return database;
     }
 
     private String[] getSaveStrings(PlayerWrapper playerWrapper) {

--- a/weaponmechanics-core/src/test/java/me/deecaad/weaponmechanics/weapon/stats/StatsHandlerTest.java
+++ b/weaponmechanics-core/src/test/java/me/deecaad/weaponmechanics/weapon/stats/StatsHandlerTest.java
@@ -1,0 +1,43 @@
+package me.deecaad.weaponmechanics.weapon.stats;
+
+import me.deecaad.weaponmechanics.wrappers.PlayerWrapper;
+import me.deecaad.weaponmechanics.wrappers.StatsData;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class StatsHandlerTest {
+
+    @Test
+    void saveDoesNotRequestDatabaseWhenStatsAreUnavailable() {
+        PlayerWrapper playerWrapper = mock(PlayerWrapper.class);
+        StatsHandler statsHandler = new StatsHandler(null, () -> {
+            throw new AssertionError("Database should not be requested when stats are unavailable");
+        });
+
+        assertDoesNotThrow(() -> statsHandler.save(playerWrapper, false));
+    }
+
+    @Test
+    void saveSkipsWhenDatabaseIsUnavailable() {
+        PlayerWrapper playerWrapper = mock(PlayerWrapper.class);
+        when(playerWrapper.getStatsData()).thenReturn(mock(StatsData.class));
+        StatsHandler statsHandler = new StatsHandler(null, () -> null);
+
+        assertDoesNotThrow(() -> statsHandler.save(playerWrapper, false));
+    }
+
+    @Test
+    void loadSkipsWhenDatabaseIsUnavailable() {
+        PlayerWrapper playerWrapper = mock(PlayerWrapper.class);
+        when(playerWrapper.getStatsDataUnsafe()).thenReturn(mock(StatsData.class));
+        StatsHandler statsHandler = new StatsHandler(null, () -> null);
+
+        assertDoesNotThrow(() -> statsHandler.load(playerWrapper));
+        verify(playerWrapper, never()).getPlayer();
+    }
+}


### PR DESCRIPTION
## Summary

- Add a nullable database accessor for lifecycle-sensitive stats code while leaving `getDatabase()` behavior unchanged for strict callers.
- Make stats load/save return early when stats are unavailable or the database is not open, so `PlayerQuitEvent` does not throw during reload/disconnect paths.
- Add focused unit coverage for disabled/unsynced stats and unavailable database cases.

## Root cause

`StatsHandler.save()` called `WeaponMechanics.getDatabase()` before checking whether the player's stats were actually available to persist. During reload/logout, `database` can be `null`, so `getDatabase()` throws `UninitializedPropertyAccessException` before the existing no-op stats guard can run.

Fixes WeaponMechanics/WeaponMechanicsCosmeticsWiki#46.

## Verification

- `git diff --check`
- `JAVA_HOME=/tmp/codex-jdk21/Contents/Home ./gradlew :weaponmechanics-core:test --no-daemon --no-configuration-cache`
