### PR TITLE
Avoid stats database access after reload

### DIFF
--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/WeaponMechanics.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/WeaponMechanics.java
@@ -485,6 +485,10 @@ public class WeaponMechanics extends MechanicsPlugin {
         return database;
     }
 
+    public @Nullable Database getDatabaseOrNull() {
+        return database;
+    }
+
     public @NotNull ProjectileSpawner getProjectileSpawner() {
         if (projectileSpawner == null)
             throw new UninitializedPropertyAccessException();

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/stats/StatsHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/stats/StatsHandler.java
@@ -27,9 +27,11 @@ public class StatsHandler {
      * @param playerWrapper the player wrapper
      */
     public void load(PlayerWrapper playerWrapper) {
-        Database database = WeaponMechanics.getInstance().getDatabase();
+        Database database = WeaponMechanics.getInstance().getDatabaseOrNull();
+        if (database == null)
+            return;
         if (database.isClosed())
-            throw new IllegalArgumentException("Tried to load data when database was closed");
+            return;
 
         StatsData statsData = playerWrapper.getStatsDataUnsafe();
         if (statsData == null)
@@ -48,9 +50,11 @@ public class StatsHandler {
      * @param forceSync true means that saving is forced to be sync (used on disable)
      */
     public void save(PlayerWrapper playerWrapper, boolean forceSync) {
-        Database database = WeaponMechanics.getInstance().getDatabase();
+        Database database = WeaponMechanics.getInstance().getDatabaseOrNull();
+        if (database == null)
+            return;
         if (database.isClosed())
-            throw new IllegalArgumentException("Tried to save data when database was closed");
+            return;
 
         StatsData statsData = playerWrapper.getStatsData();
         // This might be null if sync didn't occur...


### PR DESCRIPTION
## Summary
- add a nullable database accessor for reload/disable edge cases
- make stats load/save return when the database is unavailable or already closed
- prevents PlayerQuitEvent from throwing when a reload leaves the stats listener running after the database was cleared

Fixes WeaponMechanics/WeaponMechanicsCosmeticsWiki#46

## Testing
- `git diff --check`
- `cmd /c gradlew.bat :weaponmechanics-core:compileJava --stacktrace` could not run in this environment because only Java 25 is installed and the Kotlin Gradle script fails before task execution while parsing `25.0.1`.