### PR TITLE
Fix quit cleanup when database is unavailable

### DIFF
--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/WeaponMechanics.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/WeaponMechanics.java
@@ -485,6 +485,10 @@ public class WeaponMechanics extends MechanicsPlugin {
         return database;
     }
 
+    public @Nullable Database getDatabaseUnsafe() {
+        return database;
+    }
+
     public @NotNull ProjectileSpawner getProjectileSpawner() {
         if (projectileSpawner == null)
             throw new UninitializedPropertyAccessException();

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/listeners/trigger/TriggerPlayerListeners.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/listeners/trigger/TriggerPlayerListeners.java
@@ -55,8 +55,11 @@ public class TriggerPlayerListeners implements Listener {
     public void quit(PlayerQuitEvent e) {
         // Remove EntityWrapper data and cancel move task
         Player player = e.getPlayer();
-        weaponHandler.getStatsHandler().save(WeaponMechanics.getInstance().getPlayerWrapper(player), false);
-        WeaponMechanics.getInstance().removeEntityWrapper(player);
+        try {
+            weaponHandler.getStatsHandler().save(WeaponMechanics.getInstance().getPlayerWrapper(player), false);
+        } finally {
+            WeaponMechanics.getInstance().removeEntityWrapper(player);
+        }
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/stats/StatsHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/stats/StatsHandler.java
@@ -48,9 +48,9 @@ public class StatsHandler {
      * @param forceSync true means that saving is forced to be sync (used on disable)
      */
     public void save(PlayerWrapper playerWrapper, boolean forceSync) {
-        Database database = WeaponMechanics.getInstance().getDatabase();
-        if (database.isClosed())
-            throw new IllegalArgumentException("Tried to save data when database was closed");
+        Database database = WeaponMechanics.getInstance().getDatabaseUnsafe();
+        if (database == null || database.isClosed())
+            return;
 
         StatsData statsData = playerWrapper.getStatsData();
         // This might be null if sync didn't occur...


### PR DESCRIPTION
Summary:
- Make stats saving no-op when the database is unavailable or already closed.
- Ensure PlayerQuitEvent always removes the player wrapper even if stats saving fails.

Validation:
- git diff --check
- ./gradlew :weaponmechanics-core:compileJava --no-daemon --offline (fails because dependencies are not cached locally)
- ./gradlew :weaponmechanics-core:compileJava --no-daemon --no-configuration-cache (reached compileKotlin, then stalled locally before completion)

References WeaponMechanics/WeaponMechanicsCosmeticsWiki#46