### PR TITLE
Fix stats sync when database is unavailable

### DIFF
--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/WeaponMechanics.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/WeaponMechanics.java
@@ -485,6 +485,10 @@ public class WeaponMechanics extends MechanicsPlugin {
         return database;
     }
 
+    public @Nullable Database getDatabaseIfPresent() {
+        return database;
+    }
+
     public @NotNull ProjectileSpawner getProjectileSpawner() {
         if (projectileSpawner == null)
             throw new UninitializedPropertyAccessException();

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/stats/StatsHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/stats/StatsHandler.java
@@ -27,9 +27,12 @@ public class StatsHandler {
      * @param playerWrapper the player wrapper
      */
     public void load(PlayerWrapper playerWrapper) {
-        Database database = WeaponMechanics.getInstance().getDatabase();
+        Database database = WeaponMechanics.getInstance().getDatabaseIfPresent();
+        if (database == null)
+            return;
+
         if (database.isClosed())
-            throw new IllegalArgumentException("Tried to load data when database was closed");
+            return;
 
         StatsData statsData = playerWrapper.getStatsDataUnsafe();
         if (statsData == null)
@@ -48,9 +51,12 @@ public class StatsHandler {
      * @param forceSync true means that saving is forced to be sync (used on disable)
      */
     public void save(PlayerWrapper playerWrapper, boolean forceSync) {
-        Database database = WeaponMechanics.getInstance().getDatabase();
+        Database database = WeaponMechanics.getInstance().getDatabaseIfPresent();
+        if (database == null)
+            return;
+
         if (database.isClosed())
-            throw new IllegalArgumentException("Tried to save data when database was closed");
+            return;
 
         StatsData statsData = playerWrapper.getStatsData();
         // This might be null if sync didn't occur...


### PR DESCRIPTION
Fixes WeaponMechanics/WeaponMechanicsCosmeticsWiki#46
Fixes #610

## What changed
- Added a nullable database accessor for call sites that can safely skip persistence when the database is unavailable.
- Made stats load/save return early when the database is not initialized or already closed, preventing PlayerQuitEvent/PlayerJoinEvent from throwing during reload/disable or database-disabled states.

## Verification
- ./gradlew.bat :weaponmechanics-core:compileJava (with JDK 21)
