### PR TITLE
Fix/shielding problem and adding new features for it

### DIFF
--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/damage/DamageHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/damage/DamageHandler.java
@@ -96,11 +96,44 @@ public class DamageHandler {
         fireTicks = damageEntityEvent.getFireTicks();
         double finalDamage = damageEntityEvent.getFinalDamage();
 
+        ShieldBlocking shieldBlocking = damageEntityEvent.getShieldBlocking();
+        boolean shieldBlocked = damageEntityEvent.wasShieldBlocked();
+
+        boolean shieldBlockedProjectile = shieldBlocking != null && shieldBlocked && source instanceof ProjectileDamageSource;
+
+        boolean shouldStopBlockedProjectile = shieldBlockedProjectile && shieldBlocking.shouldStopProjectileWhenBlocked();
+
         if (DamageUtil.apply(source, victim, finalDamage)) {
+            if (shouldStopBlockedProjectile) {
+                if (victim instanceof Player player) {
+                    shieldBlocking.damageShield(player, true);
+                }
+
+                // Stop the projectile itself so Through cannot continue through the shield
+                stopProjectile(source);
+
+                // Damage was cancelled/fully blocked, but the projectile collision
+                // should still count as consumed
+                return true;
+            }
+
             WeaponMechanics.getInstance().debugger.fine("Damage was cancelled");
 
-            // Damage was cancelled
+            if (shieldBlocking != null && shieldBlocked && victim instanceof Player player) {
+                shieldBlocking.damageShield(player, false);
+            }
+
             return false;
+        }
+
+        if (shieldBlocking != null && shieldBlocked && victim instanceof Player player) {
+            shieldBlocking.damageShield(player, true);
+        }
+
+        if (shouldStopBlockedProjectile) {
+            // Even if damage was not fully zero, a successful shield block should stop
+            // the projectile when Stop_Projectile_When_Blocked is enabled
+            stopProjectile(source);
         }
 
         // Don't do WM armor damage when using vanilla damaging
@@ -267,5 +300,11 @@ public class DamageHandler {
         exposures.forEach((entity, exposure) -> {
             tryUse(source, entity, finalDamage * exposure, projectile.getHand());
         });
+    }
+
+    private void stopProjectile(@NotNull WeaponDamageSource source) {
+        if (source instanceof ProjectileDamageSource projectileSource) {
+            projectileSource.getProjectile().forceStop();
+        }
     }
 }

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/damage/DamageModifier.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/damage/DamageModifier.java
@@ -247,7 +247,7 @@ public class DamageModifier implements Serializer<DamageModifier> {
      * @param isBackStab If the hit came from behind.
      * @return The clamped rate to multiply damage by. Defaults to 1.0.
      */
-    public double getRate(@NotNull EntityWrapper wrapper, @Nullable DamagePoint point, boolean isBackStab) {
+    public double getRate(@NotNull EntityWrapper wrapper, @Nullable DamagePoint point, boolean isBackStab, boolean applyShieldModifier) {
         LivingEntity victim = wrapper.getEntity();
         double rate = 1.0;
 
@@ -306,11 +306,6 @@ public class DamageModifier implements Serializer<DamageModifier> {
         if (wrapper.isInMidair())
             rate += inMidairModifier;
 
-        // For the shield modifier, the player must be blocking with a shield
-        // and be facing the bullet.
-        if (!isBackStab && wrapper.getEntity() instanceof Player player && player.isBlocking())
-            rate += shieldModifier;
-
         // Do double damage to zombies, half damage to players (PVE scenario), for example
         if (entityTypeModifiers != null) {
             rate += entityTypeModifiers.getDouble(victim.getType());
@@ -324,8 +319,16 @@ public class DamageModifier implements Serializer<DamageModifier> {
             }
         }
 
+        if (applyShieldModifier)
+            rate += shieldModifier;
+
         // Clamp the rate within bounds
         return NumberUtil.clamp(rate, min, max);
+    }
+
+    public double getRate(@NotNull EntityWrapper wrapper, @Nullable DamagePoint point, boolean isBackStab) {
+        boolean legacyShielding = !isBackStab && wrapper.getEntity() instanceof Player player && player.isBlocking() && DamageUtil.getShieldSlot(player) != null;
+        return getRate(wrapper, point, isBackStab, legacyShielding);
     }
 
     /**
@@ -340,7 +343,7 @@ public class DamageModifier implements Serializer<DamageModifier> {
 
     /**
      * Applies all rates from this damage modifier to the given damage. This is equivalent to
-     * multiplying the damage by {@link #getRate(EntityWrapper, DamagePoint, boolean)}.
+     * multiplying the damage by {@link #getRate(EntityWrapper, DamagePoint, boolean, boolean)}.
      *
      * @param damage The damage to apply rates to.
      * @param wrapper The victim being damaged.
@@ -350,6 +353,10 @@ public class DamageModifier implements Serializer<DamageModifier> {
      */
     public double applyRates(double damage, EntityWrapper wrapper, DamagePoint point, boolean isBackStab) {
         return damage * getRate(wrapper, point, isBackStab);
+    }
+
+    public double applyRates(double damage, EntityWrapper wrapper, DamagePoint point, boolean isBackStab, boolean applyShieldModifier) {
+        return damage * getRate(wrapper, point, isBackStab, applyShieldModifier);
     }
 
     @Override

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/damage/DamageUtil.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/damage/DamageUtil.java
@@ -37,6 +37,7 @@ import org.bukkit.scoreboard.Team;
 import org.jetbrains.annotations.NotNull;
 
 import com.google.common.base.Function;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.EnumMap;
 import java.util.Set;
@@ -281,6 +282,76 @@ public class DamageUtil {
                 damage(equipment, slot, amount);
             }
         }
+    }
+
+    public static void damageShield(@NotNull Player player, int amount) {
+        if (amount <= 0)
+            return;
+
+        EntityEquipment equipment = player.getEquipment();
+
+        if (equipment == null)
+            return;
+
+        EquipmentSlot slot = getShieldSlot(player);
+
+        if (slot == null)
+            return;
+
+        ItemStack shield = slot == EquipmentSlot.HAND ? equipment.getItemInMainHand() : equipment.getItemInOffHand();
+
+        if (shield == null || shield.getType() != Material.SHIELD)
+            return;
+
+        if (shield.getType().getMaxDurability() <= 0)
+            return;
+
+        ItemMeta meta = shield.getItemMeta();
+
+        if (meta == null)
+            return;
+
+        if (meta.isUnbreakable())
+            return;
+
+        int level = meta.getEnchantLevel(Enchantment.UNBREAKING);
+        boolean skipDamage = !RandomUtil.chance(0.6 + 0.4 / (level + 1));
+
+        if (skipDamage)
+            return;
+
+        if (!(meta instanceof Damageable damageable))
+            return;
+
+        damageable.setDamage(damageable.getDamage() + amount);
+        shield.setItemMeta(meta);
+
+        if (damageable.getDamage() >= shield.getType().getMaxDurability()) {
+            shield.setAmount(0);
+        }
+
+        if (slot == EquipmentSlot.HAND) {
+            equipment.setItemInMainHand(shield);
+        } else {
+            equipment.setItemInOffHand(shield);
+        }
+    }
+
+    public static @Nullable EquipmentSlot getShieldSlot(@NotNull Player player) {
+        EntityEquipment equipment = player.getEquipment();
+
+        if (equipment == null)
+            return null;
+
+        ItemStack mainHand = equipment.getItemInMainHand();
+        if (mainHand != null && mainHand.getType() == Material.SHIELD)
+            return EquipmentSlot.HAND;
+
+        ItemStack offHand = equipment.getItemInOffHand();
+        if (offHand != null && offHand.getType() == Material.SHIELD)
+            return EquipmentSlot.OFF_HAND;
+
+        return null;
     }
 
     private static void damage(EntityEquipment equipment, EquipmentSlot slot, int amount) {

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/damage/DamageUtil.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/damage/DamageUtil.java
@@ -303,9 +303,6 @@ public class DamageUtil {
         if (shield == null || shield.getType() != Material.SHIELD)
             return;
 
-        if (shield.getType().getMaxDurability() <= 0)
-            return;
-
         ItemMeta meta = shield.getItemMeta();
 
         if (meta == null)
@@ -323,12 +320,26 @@ public class DamageUtil {
         if (!(meta instanceof Damageable damageable))
             return;
 
-        damageable.setDamage(damageable.getDamage() + amount);
-        shield.setItemMeta(meta);
+        int maxDurability = damageable.hasMaxDamage()
+                ? damageable.getMaxDamage()
+                : shield.getType().getMaxDurability();
 
-        if (damageable.getDamage() >= shield.getType().getMaxDurability()) {
-            shield.setAmount(0);
+        if (maxDurability <= 0)
+            return;
+
+        int newDamage = damageable.getDamage() + amount;
+
+        if (newDamage >= maxDurability) {
+            if (slot == EquipmentSlot.HAND) {
+                equipment.setItemInMainHand(null);
+            } else {
+                equipment.setItemInOffHand(null);
+            }
+            return;
         }
+
+        damageable.setDamage(newDamage);
+        shield.setItemMeta(meta);
 
         if (slot == EquipmentSlot.HAND) {
             equipment.setItemInMainHand(shield);

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/damage/ShieldBlocking.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/damage/ShieldBlocking.java
@@ -1,0 +1,111 @@
+package me.deecaad.weaponmechanics.weapon.damage;
+
+import me.deecaad.core.file.SerializeData;
+import me.deecaad.core.file.Serializer;
+import me.deecaad.core.file.SerializerException;
+import org.bukkit.Location;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
+
+public class ShieldBlocking implements Serializer<ShieldBlocking> {
+
+    public static final ShieldBlocking DEFAULT = new ShieldBlocking(true, false, 120.0, 0, true);
+
+    private boolean stopProjectileWhenBlocked;
+    private boolean frontOnly;
+    private double blockAngle;
+
+    private int durabilityDamage;
+    private boolean onlyWhenProjectileStopped;
+
+    public ShieldBlocking() {
+    }
+
+    public ShieldBlocking(boolean stopProjectileWhenBlocked, boolean frontOnly, double blockAngle,
+                          int durabilityDamage, boolean onlyWhenProjectileStopped) {
+        this.stopProjectileWhenBlocked = stopProjectileWhenBlocked;
+        this.frontOnly = frontOnly;
+        this.blockAngle = blockAngle;
+        this.durabilityDamage = durabilityDamage;
+        this.onlyWhenProjectileStopped = onlyWhenProjectileStopped;
+    }
+
+    public boolean shouldStopProjectileWhenBlocked() {
+        return stopProjectileWhenBlocked;
+    }
+
+    public void damageShield(@NotNull Player player, boolean projectileStopped) {
+        if (durabilityDamage <= 0)
+            return;
+
+        if (onlyWhenProjectileStopped && !projectileStopped)
+            return;
+
+        DamageUtil.damageShield(player, durabilityDamage);
+    }
+
+    public boolean isBlocking(@NotNull WeaponDamageSource source, @NotNull LivingEntity victim) {
+        if (source instanceof MeleeDamageSource meleeSource && meleeSource.isBackStab())
+            return false;
+
+        if (!(victim instanceof Player player))
+            return false;
+
+        if (!player.isBlocking())
+            return false;
+
+        EquipmentSlot shieldSlot = DamageUtil.getShieldSlot(player);
+        if (shieldSlot == null)
+            return false;
+
+        if (frontOnly && !isWithinBlockAngle(player, source.getDamageLocation()))
+            return false;
+
+        return true;
+    }
+
+    private boolean isWithinBlockAngle(@NotNull Player player, Location sourceLocation) {
+        if (sourceLocation == null)
+            return !frontOnly;
+
+        Vector facing = player.getEyeLocation().getDirection();
+        facing.setY(0.0);
+
+        if (facing.lengthSquared() == 0.0)
+            return true;
+
+        facing.normalize();
+
+        Vector toSource = sourceLocation.toVector().subtract(player.getEyeLocation().toVector());
+        toSource.setY(0.0);
+
+        if (toSource.lengthSquared() == 0.0)
+            return true;
+
+        toSource.normalize();
+
+        double threshold = Math.cos(Math.toRadians(blockAngle / 2.0));
+        return facing.dot(toSource) >= threshold;
+    }
+
+    @Override
+    public String getKeyword() {
+        return "Shield_Blocking";
+    }
+
+    @NotNull
+    @Override
+    public ShieldBlocking serialize(@NotNull SerializeData data) throws SerializerException {
+        boolean stopProjectileWhenBlocked = data.of("Stop_Projectile_When_Blocked").getBool().orElse(true);
+        boolean frontOnly = data.of("Front_Only").getBool().orElse(false);
+        double blockAngle = data.of("Block_Angle").assertRange(0.0, 360.0).getDouble().orElse(120.0);
+        int durabilityDamage = data.of("Durability.Damage").assertRange(0, null).getInt().orElse(0);
+        boolean onlyWhenProjectileStopped = data.of("Durability.Only_When_Projectile_Stopped").getBool().orElse(true);
+
+        return new ShieldBlocking(stopProjectileWhenBlocked, frontOnly, blockAngle, durabilityDamage, onlyWhenProjectileStopped
+        );
+    }
+}

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/Through.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/Through.java
@@ -45,6 +45,11 @@ public class Through implements Serializer<Through>, Cloneable {
      */
     public boolean handleThrough(WeaponProjectile projectile, RayTraceResult hit) {
 
+        // Some systems, like shield blocking, may force the projectile to stop
+        // This must override Through
+        if (projectile.isForceStopped())
+            return false;
+
         Double speedModifier;
         if (hit instanceof BlockTraceResult blockHit) {
             speedModifier = blocks != null ? blocks.isValid(blockHit.getBlockState().getType().asBlockType()) : null;

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/WeaponProjectile.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/projectile/weaponprojectile/WeaponProjectile.java
@@ -48,6 +48,7 @@ public class WeaponProjectile extends AProjectile {
     private Location lastBlock;
     private int lastEntityUpdateTick;
     private int lastEntity = -1;
+    private boolean forceStop;
 
     private final RayTrace rayTrace;
 
@@ -393,7 +394,14 @@ public class WeaponProjectile extends AProjectile {
             }
 
             // Returned true and that most likely means that block hit was cancelled, skipping...
-            if (WeaponMechanics.getInstance().getWeaponHandler().getHitHandler().handleHit(hit, this))
+            boolean skipHit = WeaponMechanics.getInstance().getWeaponHandler().getHitHandler().handleHit(hit, this);
+
+            // Some hit logic, like shield blocking, may force this projectile to stop
+            // Respect that before Through, Sticky, or Bouncy can process the same hit
+            if (isForceStopped())
+                return true;
+
+            if (skipHit)
                 continue;
 
             // Through
@@ -482,6 +490,15 @@ public class WeaponProjectile extends AProjectile {
     private boolean equalToLastHit(LivingEntity entity) {
         return lastEntity != -1 && lastEntity == entity.getEntityId() // Check entity
             && getAliveTicks() <= lastEntityUpdateTick; // Check hit tick
+    }
+
+    public void forceStop() {
+        this.forceStop = true;
+        remove();
+    }
+
+    public boolean isForceStopped() {
+        return forceStop;
     }
 
     @Override

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/weaponevents/WeaponDamageEntityEvent.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/weaponevents/WeaponDamageEntityEvent.java
@@ -11,6 +11,7 @@ import me.deecaad.weaponmechanics.weapon.damage.DamagePoint;
 import me.deecaad.weaponmechanics.weapon.damage.MeleeDamageSource;
 import me.deecaad.weaponmechanics.weapon.damage.ProjectileDamageSource;
 import me.deecaad.weaponmechanics.weapon.damage.WeaponDamageSource;
+import me.deecaad.weaponmechanics.weapon.damage.ShieldBlocking;
 import me.deecaad.weaponmechanics.wrappers.EntityWrapper;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.Cancellable;
@@ -40,6 +41,8 @@ public class WeaponDamageEntityEvent extends WeaponEvent implements Cancellable 
     private int armorDamage;
     private int fireTicks;
     private DamageDropoff dropoff;
+    private ShieldBlocking shieldBlocking;
+    private boolean shieldBlocked;
     private final List<DamageModifier> damageModifiers;
 
     private MechanicManager damageMechanics;
@@ -73,7 +76,15 @@ public class WeaponDamageEntityEvent extends WeaponEvent implements Cancellable 
         this.armorDamage = armorDamage;
         this.fireTicks = fireTicks;
         this.dropoff = WeaponMechanics.getInstance().getWeaponConfigurations().getObject(weaponTitle + ".Damage.Dropoff", DamageDropoff.class);
+        this.shieldBlocking = WeaponMechanics.getInstance().getWeaponConfigurations().getObject(weaponTitle + ".Damage.Shield_Blocking", ShieldBlocking.class);
 
+        if (this.shieldBlocking == null) {
+            this.shieldBlocking = WeaponMechanics.getInstance().getConfiguration().getObject("Damage.Shield_Blocking", ShieldBlocking.class);
+        }
+        if (this.shieldBlocking == null) {
+            this.shieldBlocking = ShieldBlocking.DEFAULT;
+        }
+        this.shieldBlocked = this.shieldBlocking.isBlocking(source, victim);
         this.damageMechanics = damageMechanics;
         this.killMechanics = killMechanics;
         this.backstabMechanics = backstabMechanics;
@@ -151,8 +162,11 @@ public class WeaponDamageEntityEvent extends WeaponEvent implements Cancellable 
 
             double rate = 1.0;
             boolean isBackStab = source instanceof MeleeDamageSource meleeSource && meleeSource.isBackStab();
+
+            shieldBlocked = shieldBlocking != null && shieldBlocking.isBlocking(source, victim);
+
             for (DamageModifier modifier : damageModifiers) {
-                rate += modifier.getRate(victimWrapper, getPoint(), isBackStab) - 1;
+                rate += modifier.getRate(victimWrapper, getPoint(), isBackStab, shieldBlocked) - 1;
             }
 
             // Clamping to the base damage
@@ -262,6 +276,19 @@ public class WeaponDamageEntityEvent extends WeaponEvent implements Cancellable 
     }
 
     /**
+     * Returns true if the last damage applied was blocked by a shield.
+     *
+     * @return true if this was blocked by a shield.
+     */
+    public boolean wasShieldBlocked() {
+        return shieldBlocked;
+    }
+
+    public ShieldBlocking getShieldBlocking() {
+        return shieldBlocking;
+    }
+
+    /**
      * Sets the number of ticks the victim should be lit on fire for.
      *
      * @param fireTicks The fire ticks.
@@ -280,7 +307,8 @@ public class WeaponDamageEntityEvent extends WeaponEvent implements Cancellable 
     }
 
     public void addDamageModifier(@Nullable DamageModifier modifier) {
-        damageModifiers.add(modifier);
+        if (modifier != null) // null guard
+            damageModifiers.add(modifier);
     }
 
     public @NotNull List<DamageModifier> getDamageModifiers() {

--- a/weaponmechanics-core/src/main/resources/WeaponMechanics/config.yml
+++ b/weaponmechanics-core/src/main/resources/WeaponMechanics/config.yml
@@ -227,6 +227,16 @@ Damage:
     Potions: []
       #- weakness +10%
 
+  Shield_Blocking:
+    Stop_Projectile_When_Blocked: true
+
+    Front_Only: false
+    Block_Angle: 120.0
+
+    Durability:
+      Damage: 0
+      Only_When_Projectile_Stopped: true
+
   Explosion:
     Damage_Modifiers:
       Min: 5%   # Explosions will always do at least 5% of their base damage


### PR DESCRIPTION
Add configurable shield blocking feature for weapon damage. Shield blocks can now stop projectiles, optionally restrict blocking to a `front-facing` angle and apply configurable shield durability damage.
Blocked projectiles also force-stop the Through system when `Stop_Projectile_When_Blocked` is enabled, preventing bullets from continuing through shielded players into entities behind them