### PR TITLE
Fix stats save when database is unavailable

### DIFF
--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/WeaponMechanics.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/WeaponMechanics.java
@@ -485,6 +485,10 @@ public class WeaponMechanics extends MechanicsPlugin {
         return database;
     }
 
+    public @Nullable Database getDatabaseOrNull() {
+        return database;
+    }
+
     public @NotNull ProjectileSpawner getProjectileSpawner() {
         if (projectileSpawner == null)
             throw new UninitializedPropertyAccessException();

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/stats/StatsHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/stats/StatsHandler.java
@@ -27,9 +27,9 @@ public class StatsHandler {
      * @param playerWrapper the player wrapper
      */
     public void load(PlayerWrapper playerWrapper) {
-        Database database = WeaponMechanics.getInstance().getDatabase();
-        if (database.isClosed())
-            throw new IllegalArgumentException("Tried to load data when database was closed");
+        Database database = WeaponMechanics.getInstance().getDatabaseOrNull();
+        if (database == null || database.isClosed())
+            return;
 
         StatsData statsData = playerWrapper.getStatsDataUnsafe();
         if (statsData == null)
@@ -48,9 +48,9 @@ public class StatsHandler {
      * @param forceSync true means that saving is forced to be sync (used on disable)
      */
     public void save(PlayerWrapper playerWrapper, boolean forceSync) {
-        Database database = WeaponMechanics.getInstance().getDatabase();
-        if (database.isClosed())
-            throw new IllegalArgumentException("Tried to save data when database was closed");
+        Database database = WeaponMechanics.getInstance().getDatabaseOrNull();
+        if (database == null || database.isClosed())
+            return;
 
         StatsData statsData = playerWrapper.getStatsData();
         // This might be null if sync didn't occur...


### PR DESCRIPTION
## Summary
- add a nullable database accessor for shutdown/reload paths
- skip stats load/save when the database is unavailable or already closed
- avoids throwing during PlayerQuitEvent if the database was not initialized or has been closed

## Testing
- ./gradlew compileJava compileKotlin
- ./gradlew test
- ./gradlew check
- ./gradlew build
- ./gradlew compileJava compileKotlin test check build --no-daemon

Fixes WeaponMechanicsCosmeticsWiki#46