### PR TITLE
Add no fall damage weapon option

### DIFF
--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/listeners/WeaponListeners.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/listeners/WeaponListeners.java
@@ -23,7 +23,9 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -121,6 +123,32 @@ public class WeaponListeners implements Listener {
         if (entityEquipment.getItemInOffHand().getType() != Material.AIR && nextSlot != null && nextSlot.getType() != Material.AIR) {
             entityWrapper.getOffHandData().cancelTasks(true);
         }
+    }
+    
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void fallDamage(EntityDamageEvent event) {
+
+        if (event.getCause() != EntityDamageEvent.DamageCause.FALL || !(event.getEntity() instanceof Player player)) {
+            return;
+        }
+
+        PlayerWrapper wrapper = WeaponMechanics.getInstance().getPlayerWrapper(player);
+
+        String mainWeapon = wrapper.getMainHandData().getCurrentWeaponTitle();
+        String offWeapon = wrapper.getOffHandData().getCurrentWeaponTitle();
+
+        if (negatesFallDamage(mainWeapon) || negatesFallDamage(offWeapon)) {
+            event.setCancelled(true);
+        }
+    }
+
+    private boolean negatesFallDamage(String weaponTitle) {
+
+        if (weaponTitle == null) {
+            return false;
+        }
+
+        return WeaponMechanics.getInstance().getWeaponConfigurations().getBoolean(weaponTitle + ".Info.No_Fall_Damage", false);
     }
 
     @EventHandler

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/info/InfoHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/info/InfoHandler.java
@@ -336,6 +336,8 @@ public class InfoHandler implements IValidator {
             configuration.set(data.getKey() + ".Weapon_Equip_Delay", weaponEquipDelay * 50);
         }
 
+        configuration.set(data.getKey() + ".No_Fall_Damage", data.of("No_Fall_Damage").getBool().orElse(false));
+
         data.of("Weapon_Get_Mechanics").serialize(MechanicManager.class)
                 .ifPresent(mechanics -> configuration.set(data.getKey() + ".Weapon_Get_Mechanics", mechanics));
         data.of("Weapon_Equip_Mechanics").serialize(MechanicManager.class)


### PR DESCRIPTION
Adds `No_Fall_Damage` option under the `Info` module to allow weapons to negate player fall damage while held