### PR TITLE
Fix explosive weapons crash on Paper 1.21.4-1.21.10

### DIFF
--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/damage/DamageHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/damage/DamageHandler.java
@@ -264,8 +264,12 @@ public class DamageHandler {
         }
 
         final double finalDamage = damage;
-        exposures.forEach((entity, exposure) -> {
+
+        for (Object2DoubleMap.Entry<LivingEntity> entry : exposures.object2DoubleEntrySet()) {
+            LivingEntity entity = entry.getKey();
+            double exposure = entry.getDoubleValue();
+
             tryUse(source, entity, finalDamage * exposure, projectile.getHand());
-        });
+        }
     }
 }

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/explode/Explosion.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/explode/Explosion.java
@@ -306,15 +306,16 @@ public class Explosion implements Serializer<Explosion> {
             // higher your exposure, the greater the knockback.
             if (isKnockback()) {
                 Vector originVector = origin.toVector();
-                entities.forEach((entity, exposure) -> {
-                    exposure *= knockbackRate;
+                for (Object2DoubleMap.Entry<LivingEntity> entry : entities.object2DoubleEntrySet()) {
+                    LivingEntity entity = entry.getKey();
+                    double exposure = entry.getDoubleValue() * knockbackRate;
 
                     // Normalized vector between the explosion and entity involved
                     Vector between = VectorUtil.setLength(entity.getLocation().toVector().subtract(originVector), exposure);
                     Vector motion = entity.getVelocity().add(between);
 
                     entity.setVelocity(motion);
-                });
+                }
             }
 
             if (cluster != null)
@@ -325,9 +326,12 @@ public class Explosion implements Serializer<Explosion> {
             // This occurs because of the command /wm test
             // Useful for debugging, and can help users decide which
             // size explosion they may want
-            entities.forEach((entity, impact) -> {
+            for (Object2DoubleMap.Entry<LivingEntity> entry : entities.object2DoubleEntrySet()) {
+                LivingEntity entity = entry.getKey();
+                double impact = entry.getDoubleValue();
+
                 entity.sendMessage(ChatColor.RED + "You suffered " + impact * 100 + "% of the impact");
-            });
+            }
         }
 
         if (flashbang != null)


### PR DESCRIPTION
This fixes a `NoClassDefFoundError` thrown when explosive weapons are used on some Paper-compatible `1.21.4-1.21.10` servers:
- it/unimi/dsi/fastutil/objects/ObjectDoubleBiConsumer Issue was caused by `Object2DoubleMap.forEach` resolving to a newer fastutil type-specific overload that is not available on those server runtimes 
- changed explosion damage, knockback, and debug impact iteration to use `object2DoubleEntrySet()` instead