### PR TITLE
Fix Impact_Mechanics not executing

### DIFF
--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/explode/Explosion.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/explode/Explosion.java
@@ -201,6 +201,8 @@ public class Explosion implements Serializer<Explosion> {
                 impactCast.setTargetLocation(origin);
             else
                 impactCast.setTargetLocation(projectile::getBukkitLocation);
+
+            impactMechanics.use(impactCast);
         }
     }
 


### PR DESCRIPTION
Fixes `Impact_Mechanics` being loaded and prepared but never executed when a projectile triggers an explosion detonation. `Explosion#handleExplosion(...)` created a `CastData` instance and assigned the projectile impact location, but did not call the configured `MechanicManager`