### PR TITLE
Expand weapon durability and add repair kits

### DIFF
--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/listeners/WeaponListeners.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/listeners/WeaponListeners.java
@@ -3,12 +3,12 @@ package me.deecaad.weaponmechanics.listeners;
 import me.deecaad.core.events.EntityEquipmentEvent;
 import me.deecaad.core.mechanics.CastData;
 import me.deecaad.core.mechanics.MechanicManager;
-import me.deecaad.core.mechanics.Mechanics;
 import me.deecaad.weaponmechanics.WeaponMechanics;
 import me.deecaad.weaponmechanics.utils.MetadataKey;
 import me.deecaad.weaponmechanics.weapon.WeaponHandler;
 import me.deecaad.weaponmechanics.weapon.damage.AssistData;
 import me.deecaad.weaponmechanics.weapon.info.WeaponInfoDisplay;
+import me.deecaad.weaponmechanics.weapon.repair.RepairResult;
 import me.deecaad.weaponmechanics.weapon.stats.WeaponStat;
 import me.deecaad.weaponmechanics.weapon.weaponevents.WeaponAssistEvent;
 import me.deecaad.weaponmechanics.weapon.weaponevents.WeaponEquipEvent;
@@ -17,17 +17,21 @@ import me.deecaad.weaponmechanics.wrappers.HandData;
 import me.deecaad.weaponmechanics.wrappers.PlayerWrapper;
 import me.deecaad.weaponmechanics.wrappers.StatsData;
 import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerItemDamageEvent;
 import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerSwapHandItemsEvent;
@@ -35,15 +39,24 @@ import org.bukkit.event.world.ChunkUnloadEvent;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.components.ToolComponent;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 public class WeaponListeners implements Listener {
 
-    private WeaponHandler weaponHandler;
+    private static final int OFF_HAND_INVENTORY_SLOT = 40;
+
+    private final WeaponHandler weaponHandler;
+    private final Map<UUID, PendingBlockDamage> pendingBlockDamage;
 
     public WeaponListeners(WeaponHandler weaponHandler) {
         this.weaponHandler = weaponHandler;
+        this.pendingBlockDamage = new HashMap<>();
     }
 
     @EventHandler
@@ -109,6 +122,56 @@ public class WeaponListeners implements Listener {
         }
     }
 
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void blockBreak(BlockBreakEvent e) {
+        // WeaponMechanicsCosmetics uses a synthetic BlockBreakEvent for visual block damage.
+        if ("WeaponMechanicsBlockDamage".equals(e.getEventName()))
+            return;
+
+        Player player = e.getPlayer();
+        if (player.getGameMode() == GameMode.CREATIVE)
+            return;
+
+        ItemStack item = player.getInventory().getItemInMainHand();
+        String weaponTitle = weaponHandler.getInfoHandler().getWeaponTitle(item, false);
+        if (weaponTitle == null)
+            return;
+
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null || meta.isUnbreakable() || !meta.hasTool())
+            return;
+
+        ToolComponent tool = meta.getTool();
+        int damagePerBlock = tool.getDamagePerBlock();
+        if (damagePerBlock <= 0)
+            return;
+
+        // PlayerItemDamageEvent may report the material's ordinary one-point loss instead of the
+        // custom ToolComponent damage. Remember this successful block break and use the component
+        // value when the corresponding item-damage event arrives.
+        pendingBlockDamage.put(player.getUniqueId(), new PendingBlockDamage(
+            item.clone(), damagePerBlock, player.getTicksLived()));
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void itemDamage(PlayerItemDamageEvent e) {
+        ItemStack item = e.getItem();
+        String weaponTitle = weaponHandler.getInfoHandler().getWeaponTitle(item, false);
+        if (weaponTitle == null)
+            return;
+
+        int durabilityDamage = e.getDamage();
+        PendingBlockDamage pending = pendingBlockDamage.remove(e.getPlayer().getUniqueId());
+        if (pending != null && pending.matches(item, e.getPlayer().getTicksLived()))
+            durabilityDamage = pending.damage();
+
+        // Custom durability must control the final transition so DISABLE can preserve the item and
+        // both modes can run the correct mechanics.
+        e.setCancelled(true);
+        weaponHandler.getDurabilityHandler().applyDurability(
+            e.getPlayer(), weaponTitle, item, durabilityDamage);
+    }
+
     @EventHandler(ignoreCancelled = true)
     public void itemHeld(PlayerItemHeldEvent e) {
         Player player = e.getPlayer();
@@ -150,11 +213,12 @@ public class WeaponListeners implements Listener {
 
     @EventHandler
     public void quit(PlayerQuitEvent e) {
-        // Cleanup metadata on player quit
         Player player = e.getPlayer();
-        if (!MetadataKey.ASSIST_DATA.has(player))
-            return;
-        MetadataKey.ASSIST_DATA.remove(player);
+        pendingBlockDamage.remove(player.getUniqueId());
+
+        // Cleanup metadata on player quit
+        if (MetadataKey.ASSIST_DATA.has(player))
+            MetadataKey.ASSIST_DATA.remove(player);
     }
 
     @EventHandler
@@ -175,7 +239,10 @@ public class WeaponListeners implements Listener {
     public void click(InventoryClickEvent e) {
         if (!(e.getWhoClicked() instanceof Player player))
             return;
+
         PlayerWrapper playerWrapper = WeaponMechanics.getInstance().getPlayerWrapper(player);
+        if (tryInventoryRepair(e, player, playerWrapper))
+            return;
 
         // Keep track of when last inventory click drop happens
         ClickType clickType = e.getClick();
@@ -192,10 +259,57 @@ public class WeaponListeners implements Listener {
         playerWrapper.getOffHandData().cancelTasks(true);
     }
 
+    private boolean tryInventoryRepair(InventoryClickEvent e, Player player, PlayerWrapper playerWrapper) {
+        if (!(e.getClickedInventory() instanceof PlayerInventory))
+            return false;
+
+        ClickType clickType = e.getClick();
+        if (clickType != ClickType.LEFT && clickType != ClickType.RIGHT)
+            return false;
+
+        ItemStack weaponStack = e.getCurrentItem();
+        ItemStack kitStack = e.getCursor();
+        EquipmentSlot weaponSlot = getEquippedSlot(player, e.getSlot());
+
+        RepairResult result = weaponHandler.getRepairHandler().tryRepair(playerWrapper, weaponStack, kitStack, weaponSlot);
+        if (!result.isHandled())
+            return false;
+
+        // A recognized kit-on-weapon click belongs to WeaponMechanics, including denied repairs.
+        // Cancelling prevents Bukkit from swapping the cursor kit with the weapon.
+        e.setCancelled(true);
+
+        if (result == RepairResult.REPAIRED) {
+            e.setCurrentItem(weaponStack);
+            e.getView().setCursor(kitStack == null || kitStack.getAmount() <= 0 ? null : kitStack);
+        }
+
+        return true;
+    }
+
+    private EquipmentSlot getEquippedSlot(Player player, int inventorySlot) {
+        if (inventorySlot == player.getInventory().getHeldItemSlot())
+            return EquipmentSlot.HAND;
+        if (inventorySlot == OFF_HAND_INVENTORY_SLOT)
+            return EquipmentSlot.OFF_HAND;
+        return null;
+    }
+
     @EventHandler(ignoreCancelled = true)
     public void swapHandItems(PlayerSwapHandItemsEvent e) {
         EntityWrapper entityWrapper = WeaponMechanics.getInstance().getEntityWrapper(e.getPlayer());
         entityWrapper.getMainHandData().cancelTasks();
         entityWrapper.getOffHandData().cancelTasks();
+    }
+
+    private record PendingBlockDamage(ItemStack item, int damage, int tick) {
+
+        private boolean matches(ItemStack damagedItem, int currentTick) {
+            int ticksPassed = currentTick - tick;
+            if (ticksPassed < 0 || ticksPassed > 1)
+                return false;
+
+            return item == damagedItem || item.isSimilar(damagedItem);
+        }
     }
 }

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/listeners/trigger/TriggerPlayerListeners.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/listeners/trigger/TriggerPlayerListeners.java
@@ -408,15 +408,17 @@ public class TriggerPlayerListeners implements Listener {
         ItemStack weapon = player.getInventory().getItemInMainHand();
         String weaponTitle = !isValid(weapon) ? null : weaponHandler.getInfoHandler().getWeaponTitle(weapon, false);
 
-        if (weaponTitle != null && WeaponMechanics.getInstance().getWeaponConfigurations().getBoolean(weaponTitle + ".Info.Cancel.Break_Blocks")) {
+        if (weaponTitle == null)
+            return;
 
-            // WeaponMechanicsCosmetics calls the BlockBreakEvent for block
-            // damage, so we need to make sure that this doesn't interfere.
-            if ("WeaponMechanicsBlockDamage".equals(event.getEventName()))
-                return;
+        // WeaponMechanicsCosmetics calls the BlockBreakEvent for block damage, so we need to make
+        // sure that this doesn't interfere with either break cancellation or depleted weapons.
+        if ("WeaponMechanicsBlockDamage".equals(event.getEventName()))
+            return;
 
+        boolean cancelBreak = WeaponMechanics.getInstance().getWeaponConfigurations().getBoolean(weaponTitle + ".Info.Cancel.Break_Blocks");
+        if (cancelBreak || weaponHandler.getDurabilityHandler().isDepleted(weapon))
             event.setCancelled(true);
-        }
     }
 
     private boolean isValid(ItemStack itemStack) {

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/utils/CustomTag.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/utils/CustomTag.java
@@ -51,6 +51,12 @@ public enum CustomTag {
     AMMO_MAGAZINE,
 
     /**
+     * Repair kit title is stored as a string, and is used to identify repair-kit items configured in
+     * WeaponMechanics/config.yml.
+     */
+    REPAIR_KIT,
+
+    /**
      * Firearm action state is stored as an int, and is used by WeaponMechanics to check if the weapon
      * is open/closed. 0 = Ready, 1 = Open, 2 = Closed.
      *

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/WeaponHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/WeaponHandler.java
@@ -4,9 +4,11 @@ import me.deecaad.core.utils.LogLevel;
 import me.deecaad.weaponmechanics.WeaponMechanics;
 import me.deecaad.weaponmechanics.listeners.trigger.TriggerPlayerListeners;
 import me.deecaad.weaponmechanics.weapon.damage.DamageHandler;
+import me.deecaad.weaponmechanics.weapon.durability.DurabilityHandler;
 import me.deecaad.weaponmechanics.weapon.info.InfoHandler;
 import me.deecaad.weaponmechanics.weapon.melee.MeleeHandler;
 import me.deecaad.weaponmechanics.weapon.reload.ReloadHandler;
+import me.deecaad.weaponmechanics.weapon.repair.RepairHandler;
 import me.deecaad.weaponmechanics.weapon.scope.ScopeHandler;
 import me.deecaad.weaponmechanics.weapon.shoot.ShootHandler;
 import me.deecaad.weaponmechanics.weapon.skin.SkinHandler;
@@ -41,6 +43,8 @@ public class WeaponHandler {
     private final ReloadHandler reloadHandler;
     private final ScopeHandler scopeHandler;
     private final DamageHandler damageHandler;
+    private final DurabilityHandler durabilityHandler;
+    private final RepairHandler repairHandler;
     private final SkinHandler skinHandler;
     private final MeleeHandler meleeHandler;
     private final StatsHandler statsHandler;
@@ -53,6 +57,8 @@ public class WeaponHandler {
         reloadHandler = new ReloadHandler(this);
         scopeHandler = new ScopeHandler(this);
         damageHandler = new DamageHandler(this);
+        durabilityHandler = new DurabilityHandler();
+        repairHandler = new RepairHandler(this);
         skinHandler = new SkinHandler(this);
         meleeHandler = new MeleeHandler(this);
         statsHandler = new StatsHandler(this);
@@ -206,6 +212,20 @@ public class WeaponHandler {
      */
     public DamageHandler getDamageHandler() {
         return damageHandler;
+    }
+
+    /**
+     * @return the durability handler
+     */
+    public DurabilityHandler getDurabilityHandler() {
+        return durabilityHandler;
+    }
+
+    /**
+     * @return the repair handler
+     */
+    public RepairHandler getRepairHandler() {
+        return repairHandler;
     }
 
     /**

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/durability/DepletedMode.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/durability/DepletedMode.java
@@ -1,0 +1,13 @@
+package me.deecaad.weaponmechanics.weapon.durability;
+
+/**
+ * Controls what happens when a weapon reaches its maximum custom damage.
+ */
+public enum DepletedMode {
+
+    /** Remove the weapon item, matching the legacy durability behavior. */
+    BREAK,
+
+    /** Keep the weapon at maximum damage until it is repaired. */
+    DISABLE
+}

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/durability/DurabilityHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/durability/DurabilityHandler.java
@@ -1,0 +1,92 @@
+package me.deecaad.weaponmechanics.weapon.durability;
+
+import me.deecaad.core.file.Configuration;
+import me.deecaad.core.mechanics.CastData;
+import me.deecaad.core.mechanics.MechanicManager;
+import me.deecaad.weaponmechanics.WeaponMechanics;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.ItemMeta;
+
+/**
+ * Handles custom weapon durability and depleted behavior.
+ */
+public class DurabilityHandler {
+
+    /**
+     * Returns whether the given custom-durability item has no durability remaining.
+     */
+    public boolean isDepleted(ItemStack weaponStack) {
+        if (weaponStack == null || weaponStack.getAmount() <= 0)
+            return true;
+
+        ItemMeta meta = weaponStack.getItemMeta();
+        return meta instanceof Damageable damageable && damageable.hasMaxDamage() && damageable.getDamage() >= damageable.getMaxDamage();
+    }
+
+    /**
+     * Returns how many uses remain before this item becomes depleted. The final use which reaches
+     * maximum damage is included in the returned amount.
+     */
+    public int getRemainingUses(ItemStack weaponStack, int damagePerUse) {
+        if (damagePerUse <= 0)
+            return Integer.MAX_VALUE;
+
+        ItemMeta meta = weaponStack.getItemMeta();
+        if (!(meta instanceof Damageable damageable) || !damageable.hasMaxDamage())
+            return Integer.MAX_VALUE;
+
+        int remainingDamage = damageable.getMaxDamage() - damageable.getDamage();
+        if (remainingDamage <= 0)
+            return 0;
+
+        return (remainingDamage + damagePerUse - 1) / damagePerUse;
+    }
+
+    /**
+     * Applies the configured durability loss for one successful shot.
+     */
+    public void applyShotDurability(LivingEntity livingEntity, String weaponTitle, ItemStack weaponStack) {
+        Configuration config = WeaponMechanics.getInstance().getWeaponConfigurations();
+        int durabilityPerShot = config.getInt(weaponTitle + ".Shoot.Durability_Per_Shot", 1);
+        applyDurability(livingEntity, weaponTitle, weaponStack, durabilityPerShot);
+    }
+
+    /**
+     * Applies durability loss from any source and handles the first transition into the depleted
+     * state. This is also used for vanilla item damage, such as Tool.Damage_Per_Block.
+     */
+    public void applyDurability(LivingEntity livingEntity, String weaponTitle, ItemStack weaponStack, int durabilityDamage) {
+        if (durabilityDamage <= 0 || weaponStack == null || weaponStack.getAmount() <= 0)
+            return;
+
+        ItemMeta meta = weaponStack.getItemMeta();
+        if (!(meta instanceof Damageable damageable) || !damageable.hasMaxDamage())
+            return;
+
+        int maxDamage = damageable.getMaxDamage();
+        int oldDamage = damageable.getDamage();
+        if (oldDamage >= maxDamage)
+            return;
+
+        int newDamage = Math.min(maxDamage, oldDamage + durabilityDamage);
+        damageable.setDamage(newDamage);
+        weaponStack.setItemMeta(meta);
+
+        if (newDamage < maxDamage)
+            return;
+
+        Configuration config = WeaponMechanics.getInstance().getWeaponConfigurations();
+        DepletedMode mode = config.getObject(weaponTitle + ".Info.Durability.On_Depleted", DepletedMode.BREAK, DepletedMode.class);
+
+        String mechanicsPath = mode == DepletedMode.DISABLE ? weaponTitle + ".Info.Weapon_Depleted_Mechanics" : weaponTitle + ".Info.Weapon_Break_Mechanics";
+
+        MechanicManager mechanics = config.getObject(mechanicsPath, MechanicManager.class);
+        if (mechanics != null)
+            mechanics.use(new CastData(livingEntity, weaponTitle, weaponStack));
+
+        if (mode == DepletedMode.BREAK)
+            weaponStack.setAmount(weaponStack.getAmount() - 1);
+    }
+}

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/durability/DurabilityHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/durability/DurabilityHandler.java
@@ -49,7 +49,7 @@ public class DurabilityHandler {
      */
     public void applyShotDurability(LivingEntity livingEntity, String weaponTitle, ItemStack weaponStack) {
         Configuration config = WeaponMechanics.getInstance().getWeaponConfigurations();
-        int durabilityPerShot = config.getInt(weaponTitle + ".Shoot.Durability_Per_Shot", 1);
+        int durabilityPerShot = config.getInt(weaponTitle + ".Shoot.Durability_Per_Shot", 0);
         applyDurability(livingEntity, weaponTitle, weaponStack, durabilityPerShot);
     }
 

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/info/InfoHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/info/InfoHandler.java
@@ -9,6 +9,7 @@ import me.deecaad.core.utils.StringUtil;
 import me.deecaad.weaponmechanics.WeaponMechanics;
 import me.deecaad.weaponmechanics.utils.CustomTag;
 import me.deecaad.weaponmechanics.weapon.WeaponHandler;
+import me.deecaad.weaponmechanics.weapon.durability.DepletedMode;
 import me.deecaad.weaponmechanics.weapon.skin.SkinSelector;
 import me.deecaad.weaponmechanics.weapon.trigger.TriggerType;
 import me.deecaad.weaponmechanics.weapon.weaponevents.WeaponGenerateEvent;
@@ -330,6 +331,9 @@ public class InfoHandler implements IValidator {
 
     @Override
     public void validate(Configuration configuration, SerializeData data) throws SerializerException {
+        DepletedMode depletedMode = data.of("Durability.On_Depleted").getEnum(DepletedMode.class).orElse(DepletedMode.BREAK);
+        configuration.set(data.getKey() + ".Durability.On_Depleted", depletedMode);
+
         int weaponEquipDelay = data.of("Weapon_Equip_Delay").assertRange(0, null).getInt().orElse(0);
         if (weaponEquipDelay != 0) {
             // Convert to millis
@@ -342,6 +346,8 @@ public class InfoHandler implements IValidator {
                 .ifPresent(mechanics -> configuration.set(data.getKey() + ".Weapon_Equip_Mechanics", mechanics));
         data.of("Weapon_Break_Mechanics").serialize(MechanicManager.class)
                 .ifPresent(mechanics -> configuration.set(data.getKey() + ".Weapon_Break_Mechanics", mechanics));
+        data.of("Weapon_Depleted_Mechanics").serialize(MechanicManager.class)
+                .ifPresent(mechanics -> configuration.set(data.getKey() + ".Weapon_Depleted_Mechanics", mechanics));
         data.of("Weapon_Holster_Mechanics").serialize(MechanicManager.class)
                 .ifPresent(mechanics -> configuration.set(data.getKey() + ".Weapon_Holster_Mechanics", mechanics));
     }

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/repair/RepairConfig.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/repair/RepairConfig.java
@@ -1,0 +1,116 @@
+package me.deecaad.weaponmechanics.weapon.repair;
+
+import me.deecaad.core.file.SerializeData;
+import me.deecaad.core.file.Serializer;
+import me.deecaad.core.file.SerializerException;
+import me.deecaad.core.file.serializers.ItemSerializer;
+import me.deecaad.weaponmechanics.utils.CustomTag;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Global repair settings loaded from the top-level Repair section in config.yml.
+ */
+public final class RepairConfig implements Serializer<RepairConfig> {
+
+    private static final Pattern KIT_NAME_PATTERN = Pattern.compile("[A-Za-z0-9_]+");
+
+    private final boolean enabled;
+    private final Map<String, RepairKit> kits;
+    private final boolean allowRepairWhileFull;
+    private final boolean allowRepairWhileReloading;
+    private final boolean allowRepairWhileShooting;
+    private final boolean excessRepairIsWasted;
+
+    public RepairConfig() {
+        this(false, Collections.emptyMap(), false, false, false, true);
+    }
+
+    private RepairConfig(boolean enabled, Map<String, RepairKit> kits, boolean allowRepairWhileFull,
+                         boolean allowRepairWhileReloading, boolean allowRepairWhileShooting,
+                         boolean excessRepairIsWasted) {
+        this.enabled = enabled;
+        this.kits = Collections.unmodifiableMap(new LinkedHashMap<>(kits));
+        this.allowRepairWhileFull = allowRepairWhileFull;
+        this.allowRepairWhileReloading = allowRepairWhileReloading;
+        this.allowRepairWhileShooting = allowRepairWhileShooting;
+        this.excessRepairIsWasted = excessRepairIsWasted;
+    }
+
+    @Override
+    public String getKeyword() {
+        return "Repair";
+    }
+
+    @Override
+    public boolean shouldSerialize(@NotNull SerializeData data) {
+        // Weapon files also use a Repair section for Allowed_Kits. This serializer is only for the
+        // single top-level section in WeaponMechanics/config.yml.
+        return "Repair".equals(data.getKey());
+    }
+
+    @Override
+    public @NotNull RepairConfig serialize(@NotNull SerializeData data) throws SerializerException {
+        boolean enabled = data.of("Enabled").getBool().orElse(false);
+        boolean allowRepairWhileFull = data.of("Allow_Repair_While_Full").getBool().orElse(false);
+        boolean allowRepairWhileReloading = data.of("Allow_Repair_While_Reloading").getBool().orElse(false);
+        boolean allowRepairWhileShooting = data.of("Allow_Repair_While_Shooting").getBool().orElse(false);
+        boolean excessRepairIsWasted = data.of("Excess_Repair_Is_Wasted").getBool().orElse(true);
+
+        Map<String, RepairKit> kits = new LinkedHashMap<>();
+        ConfigurationSection kitsSection = data.of("Kits").get(ConfigurationSection.class).orElse(null);
+        if (kitsSection != null) {
+            ItemSerializer itemSerializer = new ItemSerializer();
+
+            for (String kitName : kitsSection.getKeys(false)) {
+                if (!KIT_NAME_PATTERN.matcher(kitName).matches()) {
+                    throw data.exception("Kits." + kitName, "Repair kit names may only contain letters, numbers, and underscores.", "Found repair kit: " + kitName);
+                }
+
+                SerializeData kitData = data.move("Kits." + kitName);
+                ItemStack item = itemSerializer.serializeWithTags(kitData.move("Item"), Map.of(CustomTag.REPAIR_KIT.getKey(), kitName));
+
+                int repairAmount = kitData.of("Repair_Amount").assertExists().assertRange(1, null).getInt().getAsInt();
+                boolean consumeItem = kitData.of("Consume_Item").getBool().orElse(true);
+
+                kits.put(kitName, new RepairKit(kitName, item, repairAmount, consumeItem));
+            }
+        }
+
+        return new RepairConfig(enabled, kits, allowRepairWhileFull, allowRepairWhileReloading, allowRepairWhileShooting, excessRepairIsWasted);
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public RepairKit getKit(String name) {
+        return kits.get(name);
+    }
+
+    public Map<String, RepairKit> getKits() {
+        return kits;
+    }
+
+    public boolean isAllowRepairWhileFull() {
+        return allowRepairWhileFull;
+    }
+
+    public boolean isAllowRepairWhileReloading() {
+        return allowRepairWhileReloading;
+    }
+
+    public boolean isAllowRepairWhileShooting() {
+        return allowRepairWhileShooting;
+    }
+
+    public boolean isExcessRepairWasted() {
+        return excessRepairIsWasted;
+    }
+}

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/repair/RepairHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/repair/RepairHandler.java
@@ -1,0 +1,100 @@
+package me.deecaad.weaponmechanics.weapon.repair;
+
+import me.deecaad.core.file.Configuration;
+import me.deecaad.weaponmechanics.WeaponMechanics;
+import me.deecaad.weaponmechanics.utils.CustomTag;
+import me.deecaad.weaponmechanics.weapon.WeaponHandler;
+import me.deecaad.weaponmechanics.wrappers.HandData;
+import me.deecaad.weaponmechanics.wrappers.PlayerWrapper;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Handles applying repair kits to weapons from inventory interactions.
+ */
+public class RepairHandler {
+
+    private final WeaponHandler weaponHandler;
+
+    public RepairHandler(WeaponHandler weaponHandler) {
+        this.weaponHandler = weaponHandler;
+    }
+
+    /**
+     * Attempts to apply {@code kitStack} to {@code weaponStack}.
+     *
+     * @param playerWrapper the player performing the repair
+     * @param weaponStack the clicked weapon
+     * @param kitStack the repair kit held by the inventory cursor
+     * @param weaponSlot the equipped hand containing the weapon, or {@code null} when the clicked
+     *                   weapon is not currently equipped
+     * @return whether the click was unrelated, denied, or repaired successfully
+     */
+    public RepairResult tryRepair(PlayerWrapper playerWrapper, ItemStack weaponStack, ItemStack kitStack, @Nullable EquipmentSlot weaponSlot) {
+        RepairConfig repairConfig = WeaponMechanics.getInstance().getConfiguration().getObject("Repair", RepairConfig.class);
+        if (repairConfig == null || !repairConfig.isEnabled())
+            return RepairResult.NOT_APPLICABLE;
+
+        if (weaponStack == null || kitStack == null || weaponStack.getAmount() <= 0 || kitStack.getAmount() <= 0) {
+            return RepairResult.NOT_APPLICABLE;
+        }
+
+        String weaponTitle = weaponHandler.getInfoHandler().getWeaponTitle(weaponStack, false);
+        if (weaponTitle == null || !CustomTag.REPAIR_KIT.hasString(kitStack))
+            return RepairResult.NOT_APPLICABLE;
+
+        String kitName = CustomTag.REPAIR_KIT.getString(kitStack);
+        RepairKit kit = repairConfig.getKit(kitName);
+        if (kit == null)
+            return RepairResult.DENIED;
+
+        Configuration weaponConfig = WeaponMechanics.getInstance().getWeaponConfigurations();
+        List<?> allowedKits = weaponConfig.getObject(weaponTitle + ".Repair.Allowed_Kits", Collections.emptyList(), List.class);
+        if (!allowedKits.contains(kitName))
+            return RepairResult.DENIED;
+
+        ItemMeta meta = weaponStack.getItemMeta();
+        if (!(meta instanceof Damageable damageable) || !damageable.hasMaxDamage())
+            return RepairResult.DENIED;
+
+        int currentDamage = damageable.getDamage();
+        if (currentDamage <= 0 && !repairConfig.isAllowRepairWhileFull())
+            return RepairResult.DENIED;
+
+        HandData handData = getHandData(playerWrapper, weaponSlot);
+        if (handData != null) {
+            if (!repairConfig.isAllowRepairWhileReloading() && handData.isReloading())
+                return RepairResult.DENIED;
+
+            if (!repairConfig.isAllowRepairWhileShooting() && (handData.isUsingFullAuto() || handData.isUsingBurst())) {
+                return RepairResult.DENIED;
+            }
+        }
+
+        if (!repairConfig.isExcessRepairWasted() && kit.getRepairAmount() > currentDamage)
+            return RepairResult.DENIED;
+
+        int newDamage = Math.max(0, currentDamage - kit.getRepairAmount());
+        damageable.setDamage(newDamage);
+        weaponStack.setItemMeta(meta);
+
+        if (kit.isConsumeItem())
+            kitStack.setAmount(kitStack.getAmount() - 1);
+
+        return RepairResult.REPAIRED;
+    }
+
+    private HandData getHandData(PlayerWrapper playerWrapper, @Nullable EquipmentSlot weaponSlot) {
+        if (weaponSlot == EquipmentSlot.HAND)
+            return playerWrapper.getMainHandData();
+        if (weaponSlot == EquipmentSlot.OFF_HAND)
+            return playerWrapper.getOffHandData();
+        return null;
+    }
+}

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/repair/RepairKit.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/repair/RepairKit.java
@@ -1,0 +1,37 @@
+package me.deecaad.weaponmechanics.weapon.repair;
+
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * An immutable repair-kit definition loaded from config.yml.
+ */
+public final class RepairKit {
+
+    private final String name;
+    private final ItemStack item;
+    private final int repairAmount;
+    private final boolean consumeItem;
+
+    public RepairKit(String name, ItemStack item, int repairAmount, boolean consumeItem) {
+        this.name = name;
+        this.item = item;
+        this.repairAmount = repairAmount;
+        this.consumeItem = consumeItem;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public ItemStack getItem() {
+        return item.clone();
+    }
+
+    public int getRepairAmount() {
+        return repairAmount;
+    }
+
+    public boolean isConsumeItem() {
+        return consumeItem;
+    }
+}

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/repair/RepairResult.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/repair/RepairResult.java
@@ -1,0 +1,23 @@
+package me.deecaad.weaponmechanics.weapon.repair;
+
+/**
+ * Result of attempting to apply a repair kit to a weapon.
+ */
+public enum RepairResult {
+
+    /** The clicked items were not a weapon/repair-kit pair. */
+    NOT_APPLICABLE,
+
+    /** The pair was recognized, but the repair was rejected by configuration or weapon state. */
+    DENIED,
+
+    /** The weapon was repaired successfully. */
+    REPAIRED;
+
+    /**
+     * Returns whether WeaponMechanics should consume the inventory click.
+     */
+    public boolean isHandled() {
+        return this != NOT_APPLICABLE;
+    }
+}

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/repair/RepairValidator.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/repair/RepairValidator.java
@@ -1,0 +1,52 @@
+package me.deecaad.weaponmechanics.weapon.repair;
+
+import me.deecaad.core.file.Configuration;
+import me.deecaad.core.file.IValidator;
+import me.deecaad.core.file.SearchMode;
+import me.deecaad.core.file.SearcherFilter;
+import me.deecaad.core.file.SerializeData;
+import me.deecaad.core.file.SerializerException;
+import me.deecaad.weaponmechanics.WeaponMechanics;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Validates the per-weapon Repair.Allowed_Kits section.
+ */
+@SearcherFilter(SearchMode.ON_DEMAND)
+public class RepairValidator implements IValidator {
+
+    @Override
+    public String getKeyword() {
+        return "Repair";
+    }
+
+    @Override
+    public List<String> getAllowedPaths() {
+        return Collections.singletonList(".Repair");
+    }
+
+    @Override
+    public void validate(Configuration configuration, SerializeData data) throws SerializerException {
+        List<?> configuredKits = data.of("Allowed_Kits").get(List.class).orElse(Collections.emptyList());
+        List<String> allowedKits = new ArrayList<>(configuredKits.size());
+
+        RepairConfig repairConfig = WeaponMechanics.getInstance().getConfiguration().getObject("Repair", RepairConfig.class);
+
+        for (Object value : configuredKits) {
+            if (!(value instanceof String kitName)) {
+                throw data.exception("Allowed_Kits", "Every Allowed_Kits entry must be a repair-kit name.", "Found value: " + value);
+            }
+
+            if (repairConfig == null || repairConfig.getKit(kitName) == null) {
+                throw data.exception("Allowed_Kits", "Unknown repair kit '" + kitName + "'.", "Define it under Repair.Kits in WeaponMechanics/config.yml first.");
+            }
+
+            allowedKits.add(kitName);
+        }
+
+        configuration.set(data.getKey() + ".Allowed_Kits", List.copyOf(allowedKits));
+    }
+}

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/shoot/FullAutoTask.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/shoot/FullAutoTask.java
@@ -156,7 +156,7 @@ public class FullAutoTask implements Consumer<TaskImplementation<Void>> {
     @Override
     public void accept(@NotNull TaskImplementation task) {
         ItemStack taskReference = mainHand ? entityWrapper.getEntity().getEquipment().getItemInMainHand() : entityWrapper.getEntity().getEquipment().getItemInOffHand();
-        if (!taskReference.hasItemMeta()) {
+        if (!taskReference.hasItemMeta() || weaponHandler.getDurabilityHandler().isDepleted(taskReference)) {
             task.cancel();
             handData.setFullAutoTask(null, null);
             return;
@@ -184,8 +184,17 @@ public class FullAutoTask implements Consumer<TaskImplementation<Void>> {
         }
 
         // Determine if we should shoot on this tick. The AUTO array is a table of basically true/false
-        // values.
+        // values. Limit the batch to the number of durability uses remaining so we do not consume
+        // ammunition for queued shots which cannot actually fire.
         int shootAmount = perShot + AUTO[rate][currentTick];
+        int durabilityPerShot = WeaponMechanics.getInstance().getWeaponConfigurations().getInt(weaponTitle + ".Shoot.Durability_Per_Shot", 1);
+        shootAmount = Math.min(shootAmount, weaponHandler.getDurabilityHandler().getRemainingUses(taskReference, durabilityPerShot));
+
+        if (shootAmount <= 0) {
+            task.cancel();
+            handData.setFullAutoTask(null, null);
+            return;
+        }
 
         // START RELOAD STUFF
         if (ammoLeft != -1) {
@@ -209,6 +218,13 @@ public class FullAutoTask implements Consumer<TaskImplementation<Void>> {
         for (int i = 0; i < shootAmount; ++i) {
             Location shootLocation = weaponHandler.getShootHandler().getShootLocation(entityWrapper, weaponTitle, mainHand);
             weaponHandler.getShootHandler().shoot(entityWrapper, weaponTitle, taskReference, shootLocation, mainHand, true, false);
+
+            if (weaponHandler.getDurabilityHandler().isDepleted(taskReference)) {
+                task.cancel();
+                handData.setFullAutoTask(null, null);
+                return;
+            }
+
             boolean consumeEmpty = destroyWhenEmpty && CustomTag.AMMO_LEFT.getInteger(weaponStack) == 0;
             if ((consumeEmpty || consumeItemOnShoot) && weaponHandler.getShootHandler().handleConsumeItemOnShoot(weaponStack, handData)) {
                 return;

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/shoot/ShootHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/shoot/ShootHandler.java
@@ -756,7 +756,7 @@ public class ShootHandler implements IValidator, TriggerListener {
         int projectilesPerShot = data.of("Projectiles_Per_Shot").assertRange(1, 100).getInt().orElse(1);
         configuration.set(data.getKey() + ".Projectiles_Per_Shot", projectilesPerShot);
 
-        int durabilityPerShot = data.of("Durability_Per_Shot").assertRange(0, null).getInt().orElse(1);
+        int durabilityPerShot = data.of("Durability_Per_Shot").assertRange(0, null).getInt().orElse(0);
         configuration.set(data.getKey() + ".Durability_Per_Shot", durabilityPerShot);
 
         boolean hasBurst = false;

--- a/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/shoot/ShootHandler.java
+++ b/weaponmechanics-core/src/main/java/me/deecaad/weaponmechanics/weapon/shoot/ShootHandler.java
@@ -47,8 +47,6 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.Damageable;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.Nullable;
 
@@ -95,6 +93,11 @@ public class ShootHandler implements IValidator, TriggerListener {
      */
     public boolean shootWithoutTrigger(EntityWrapper entityWrapper, String weaponTitle, ItemStack weaponStack, EquipmentSlot slot, TriggerType triggerType, boolean dualWield) {
         HandData handData = slot == EquipmentSlot.HAND ? entityWrapper.getMainHandData() : entityWrapper.getOffHandData();
+
+        // DISABLE keeps the weapon item, so explicitly prevent depleted weapons from shooting. This
+        // also protects malformed/generated BREAK weapons which already start at maximum damage.
+        if (weaponHandler.getDurabilityHandler().isDepleted(weaponStack))
+            return false;
 
         // Don't even try if slot is already being used for full auto or burst
         if (handData.isUsingFullAuto() || handData.isUsingBurst())
@@ -288,7 +291,7 @@ public class ShootHandler implements IValidator, TriggerListener {
             @Override
             public void accept(TaskImplementation<Void> scheduledTask) {
                 ItemStack taskReference = mainhand ? entityWrapper.getEntity().getEquipment().getItemInMainHand() : entityWrapper.getEntity().getEquipment().getItemInOffHand();
-                if (!taskReference.hasItemMeta()) {
+                if (!taskReference.hasItemMeta() || weaponHandler.getDurabilityHandler().isDepleted(taskReference)) {
                     handData.setBurstTask(null);
                     scheduledTask.cancel();
                     return;
@@ -316,6 +319,12 @@ public class ShootHandler implements IValidator, TriggerListener {
 
                 // Only make the first projectile of burst modify spread change if its used
                 shoot(entityWrapper, weaponTitle, taskReference, getShootLocation(entityWrapper, weaponTitle, mainhand), mainhand, shots == 0, false);
+
+                if (weaponHandler.getDurabilityHandler().isDepleted(taskReference)) {
+                    handData.setBurstTask(null);
+                    scheduledTask.cancel();
+                    return;
+                }
 
                 boolean consumeEmpty = config.getBoolean(weaponTitle + ".Shoot.Destroy_When_Empty") && CustomTag.AMMO_LEFT.getInteger(weaponStack) == 0;
                 if ((consumeEmpty || consumeItemOnShoot) && handleConsumeItemOnShoot(weaponStack, mainhand ? entityWrapper.getMainHandData() : entityWrapper.getOffHandData())) {
@@ -628,27 +637,8 @@ public class ShootHandler implements IValidator, TriggerListener {
         handData.setLastShotTime(System.currentTimeMillis());
         handData.setLastWeaponShot(weaponTitle, weaponStack);
 
-        // Apply custom durability
-        ItemMeta meta = weaponStack.getItemMeta();
-        if (meta instanceof Damageable damageable && damageable.hasMaxDamage()) {
-            int durabilityPerShot = config.getInt(weaponTitle + ".Shoot.Durability_Per_Shot", 1);
-
-            if (durabilityPerShot > 0) {
-                int maxDamage = damageable.getMaxDamage();
-                int newDamage = Math.min(maxDamage, damageable.getDamage() + durabilityPerShot);
-                damageable.setDamage(newDamage);
-
-                if (newDamage >= maxDamage) {
-                    MechanicManager breakMechanics = config.getObject(weaponTitle + ".Info.Weapon_Break_Mechanics", MechanicManager.class);
-                    if (breakMechanics != null)
-                        breakMechanics.use(new CastData(livingEntity, weaponTitle, weaponStack));
-
-                    weaponStack.setAmount(weaponStack.getAmount() - 1);
-                }
-
-                weaponStack.setItemMeta(meta);
-            }
-        }
+        // Apply custom durability only after a successful shot.
+        weaponHandler.getDurabilityHandler().applyShotDurability(livingEntity, weaponTitle, weaponStack);
     }
 
     /**

--- a/weaponmechanics-core/src/main/kotlin/me/deecaad/weaponmechanics/WeaponMechanicsCommand.kt
+++ b/weaponmechanics-core/src/main/kotlin/me/deecaad/weaponmechanics/WeaponMechanicsCommand.kt
@@ -66,6 +66,7 @@ import me.deecaad.weaponmechanics.weapon.explode.shapes.SphereExplosion
 import me.deecaad.weaponmechanics.weapon.projectile.weaponprojectile.Projectile
 import me.deecaad.weaponmechanics.weapon.projectile.weaponprojectile.ProjectileSettings
 import me.deecaad.weaponmechanics.weapon.reload.ammo.AmmoConfig
+import me.deecaad.weaponmechanics.weapon.repair.RepairConfig
 import me.deecaad.weaponmechanics.weapon.shoot.SelectiveFireState
 import me.deecaad.weaponmechanics.weapon.shoot.recoil.RecoilProfile
 import net.kyori.adventure.text.Component
@@ -219,6 +220,31 @@ object WeaponMechanicsCommand {
                     val amount = args["amount"] as? Int ?: 64
 
                     giveAmmo(sender, target, ammoType, magazine, amount)
+                }
+            }
+
+            subcommand("repairkit") {
+                withPermission("weaponmechanics.commands.repairkit")
+                withShortDescription("Gives a configured weapon repair kit")
+
+                entitySelectorArgumentManyPlayers("target")
+                stringArgument("kit") {
+                    replaceSuggestions(
+                        ArgumentSuggestions.strings {
+                            val repair = WeaponMechanics.getInstance().configuration
+                                .getObject("Repair", RepairConfig::class.java)
+                            repair?.kits?.keys?.toTypedArray() ?: emptyArray<String>()
+                        },
+                    )
+                }
+                integerArgument("amount", 1, 64, optional = true)
+
+                anyExecutor { sender, args ->
+                    val targets = args["target"] as List<Player>
+                    val kitName = args["kit"] as String
+                    val amount = args["amount"] as? Int ?: 1
+
+                    giveRepairKit(sender, targets, kitName, amount)
                 }
             }
 
@@ -773,6 +799,48 @@ object WeaponMechanicsCommand {
         } else {
             sender.sendMessage(ChatColor.GREEN.toString() + player.name + " recieved " + amount + " " + ammoName)
         }
+    }
+
+    fun giveRepairKit(
+        sender: CommandSender,
+        targets: List<Player>,
+        kitName: String,
+        amount: Int,
+    ) {
+        val repairConfig = WeaponMechanics.getInstance().configuration
+            .getObject("Repair", RepairConfig::class.java)
+        val kit = repairConfig?.getKit(kitName)
+
+        if (kit == null) {
+            sender.sendMessage(ChatColor.RED.toString() + "Unknown repair kit: " + kitName)
+            return
+        }
+
+        if (targets.isEmpty()) {
+            sender.sendMessage(ChatColor.RED.toString() + "No players were found")
+            return
+        }
+
+        var successful = 0
+        for (target in targets) {
+            val item = kit.item
+            item.amount = amount
+
+            val overflow = target.inventory.addItem(item)
+            if (overflow.isEmpty()) {
+                successful++
+            } else {
+                for (remaining in overflow.values) {
+                    target.world.dropItemNaturally(target.location, remaining)
+                }
+                successful++
+            }
+        }
+
+        sender.sendMessage(
+            ChatColor.GREEN.toString() + "Gave " + amount + " " + kitName +
+                " to " + successful + " player" + (if (successful == 1) "" else "s"),
+        )
     }
 
     enum class RepairMode {

--- a/weaponmechanics-core/src/main/resources/WeaponMechanics/config.yml
+++ b/weaponmechanics-core/src/main/resources/WeaponMechanics/config.yml
@@ -28,6 +28,23 @@ Database:
   SQLite:
     Absolute_Path: "plugins/WeaponMechanics/weaponmechanics.db"
 
+# Global repair-kit definitions. To repair a weapon, pick up a configured repair kit with
+# the inventory cursor and click it onto an allowed damaged weapon in the player's inventory.
+Repair:
+  Enabled: false
+
+  # Add reusable repair-kit definitions here. Concrete kits are intentionally not included in the
+  # defaults so removing a custom kit does not cause WeaponMechanics to regenerate it on reload.
+  Kits: {}
+
+  Allow_Repair_While_Full: false
+  Allow_Repair_While_Reloading: false
+  Allow_Repair_While_Shooting: false
+
+  # When false, a kit cannot be used if its full Repair_Amount would exceed the
+  # weapon's missing durability.
+  Excess_Repair_Is_Wasted: true
+
 # Used to keep track of weapon assists
 Assists_Event:
   Enable: true


### PR DESCRIPTION
Expands weapon durability with configurable `BREAK` and `DISABLE` depletion modes, separate break/depleted mechanics, repair kits, `Mending` support and correct `Tool.Damage_Per_Block` handling. Repair kits are defined globally, allowed per weapon, and applied by clicking a kit from the inventory cursor onto a damaged weapon. Tested with `single`, `burst`, and `fully automatic` fire (both depletion modes), inventory repairs and restrictions, `Mending`, custom block wear, and `WMC` block damage as well.